### PR TITLE
chore: include for region tags to keep the content the same on cloud.google.com as it is on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ If you are using Maven with Bom, Add this to your pom.xml file.
 [//]: # ({x-version-update-start:google-cloud-logging:released})
 If you are using Maven without Bom, Add this to your dependencies.
 ```xml
-<!-- [START logging_install_without_bom -->
+<!-- [START logging_install_without_bom] -->
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging</artifactId>
   <version>1.99.0</version>
 </dependency>
-<!-- [END logging_install_without_bom -->
+<!-- [END logging_install_without_bom] -->
 ```
 If you are using Gradle, add this to your dependencies
 ```Groovy

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Quickstart
 ----------
 If you are using Maven with Bom, Add this to your pom.xml file.
 ```xml
+<!-- [START logging_install_with_bom] -->
 <dependencyManagement>
  <dependencies>
   <dependency>
@@ -30,15 +31,18 @@ If you are using Maven with Bom, Add this to your pom.xml file.
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging</artifactId>
 </dependency>
+<!-- [END logging_install_with_bom] -->
 ```
 [//]: # ({x-version-update-start:google-cloud-logging:released})
 If you are using Maven without Bom, Add this to your dependencies.
 ```xml
+<!-- [START logging_install_without_bom -->
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging</artifactId>
   <version>1.99.0</version>
 </dependency>
+<!-- [END logging_install_without_bom -->
 ```
 If you are using Gradle, add this to your dependencies
 ```Groovy


### PR DESCRIPTION
The content at https://cloud.google.com/logging/docs/reference/libraries is not same as what's on GitHub. Monitoring had the same issue (see https://github.com/googleapis/java-monitoring/commit/b6a565777c9729852d6c47a3f2a3ceee7ad6540b)

