### PR TITLE
samples: migrate logging samples from java-docs-samples

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,4 +308,13 @@
       </plugin>
     </plugins>
   </reporting>
+
+  <profiles>
+    <profile>
+      <id>enable-samples</id>
+      <modules>
+        <module>samples</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/samples/install-with-bom/pom.xml
+++ b/samples/install-with-bom/pom.xml
@@ -1,0 +1,76 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>logging-install-with-bom</artifactId>
+  <packaging>jar</packaging>
+  <name>Google Cloud Logging Install With BOM Sample</name>
+  <url>https://github.com/googleapis/java-logging</url>
+
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-logging-samples</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <!-- [START logging_install_with_bom] -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>4.1.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-logging</artifactId>
+    </dependency>
+  </dependencies>
+  <!-- [END logging_install_with_bom] -->
+
+  <!-- compile and run all snippet tests -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-snippets-source</id>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>../snippets/src/main/java</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-snippets-tests</id>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>../snippets/src/test/java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -1,0 +1,67 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>logging-install-without-bom</artifactId>
+  <packaging>jar</packaging>
+  <name>Google Cloud Logging Install Without BOM Sample</name>
+  <url>https://github.com/googleapis/java-logging</url>
+
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-logging-samples</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <!-- {x-version-update-start:google-cloud-logging:released} -->
+  <dependencies>
+    <!-- [START logging_install_without_bom] -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-logging</artifactId>
+      <version>1.100.0</version>
+    </dependency>
+    <!-- [END logging_install_without_bom] -->
+  </dependencies>
+  <!-- {x-version-update-end} -->
+
+  <!-- compile and run all snippet tests -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-snippets-source</id>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>../snippets/src/main/java</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-snippets-tests</id>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>../snippets/src/test/java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>google-cloud-logging-samples</artifactId>
+  <version>0.0.1-SNAPSHOT</version><!-- This artifact should not be released -->
+  <packaging>pom</packaging>
+  <name>Google Cloud Logging Samples Parent</name>
+  <url>https://github.com/googleapis/java-logging</url>
+  <description>
+    Java idiomatic client for Google Cloud Platform services.
+  </description>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in any way.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.0.11</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <modules>
+    <module>install-with-bom</module>
+    <module>install-without-bom</module>
+    <module>snippets</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.8</version>
+        <configuration>
+          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.0.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.cloud</groupId>
+  <artifactId>logging-snippets</artifactId>
+  <packaging>jar</packaging>
+  <name>Google Cloud Logging Snippets</name>
+  <url>https://github.com/googleapis/java-logging</url>
+
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-logging-samples</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-logging</artifactId>
+      <version>1.100.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+    </dependency>
+  </dependencies>
+</project>

--- a/samples/snippets/src/main/java/com/example/logging/ListLogs.java
+++ b/samples/snippets/src/main/java/com/example/logging/ListLogs.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.logging;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.logging.LogEntry;
+import com.google.cloud.logging.Logging;
+import com.google.cloud.logging.Logging.EntryListOption;
+import com.google.cloud.logging.LoggingOptions;
+
+/**
+ * List logs programmatically using the StackDriver Logging API.
+ */
+public class ListLogs {
+
+  /** Expects an existing Stackdriver log name as an argument. */
+  public static void main(String... args) throws Exception {
+    // [START logging_list_log_entries]
+    // Instantiates a client
+    LoggingOptions options = LoggingOptions.getDefaultInstance();
+
+    String logName = args[0];
+
+    try (Logging logging = options.getService()) {
+
+      String logFilter = "logName=projects/" + options.getProjectId() + "/logs/" + logName;
+
+      // List all log entries
+      Page<LogEntry> entries = logging.listLogEntries(
+          EntryListOption.filter(logFilter));
+      do {
+        for (LogEntry logEntry : entries.iterateAll()) {
+          System.out.println(logEntry);
+        }
+        entries = entries.getNextPage();
+      } while (entries != null);
+
+    }
+    // [END logging_list_log_entries]
+  }
+}

--- a/samples/snippets/src/main/java/com/example/logging/ListLogs.java
+++ b/samples/snippets/src/main/java/com/example/logging/ListLogs.java
@@ -22,9 +22,7 @@ import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.Logging.EntryListOption;
 import com.google.cloud.logging.LoggingOptions;
 
-/**
- * List logs programmatically using the StackDriver Logging API.
- */
+/** List logs programmatically using the StackDriver Logging API. */
 public class ListLogs {
 
   /** Expects an existing Stackdriver log name as an argument. */
@@ -40,15 +38,13 @@ public class ListLogs {
       String logFilter = "logName=projects/" + options.getProjectId() + "/logs/" + logName;
 
       // List all log entries
-      Page<LogEntry> entries = logging.listLogEntries(
-          EntryListOption.filter(logFilter));
+      Page<LogEntry> entries = logging.listLogEntries(EntryListOption.filter(logFilter));
       do {
         for (LogEntry logEntry : entries.iterateAll()) {
           System.out.println(logEntry);
         }
         entries = entries.getNextPage();
       } while (entries != null);
-
     }
     // [END logging_list_log_entries]
   }

--- a/samples/snippets/src/main/java/com/example/logging/QuickstartSample.java
+++ b/samples/snippets/src/main/java/com/example/logging/QuickstartSample.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.logging;
+
+// [START logging_quickstart]
+import com.google.cloud.MonitoredResource;
+import com.google.cloud.logging.LogEntry;
+import com.google.cloud.logging.Logging;
+import com.google.cloud.logging.LoggingOptions;
+import com.google.cloud.logging.Payload.StringPayload;
+import com.google.cloud.logging.Severity;
+import java.util.Collections;
+
+/**
+ * This sample demonstrates writing logs using the Stackdriver Logging API.
+ * The library also offers a java.util.logging Handler `com.google.cloud.logging.LoggingHandler`
+ * Logback integration is also available :
+ * https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-contrib/google-cloud-logging-logback
+ * Using the java.util.logging handler / Logback appender should be preferred to using the API
+ * directly.
+ */
+public class QuickstartSample {
+
+  /** Expects a new or existing Stackdriver log name as the first argument.*/
+  public static void main(String... args) throws Exception {
+
+    // Instantiates a client
+    Logging logging = LoggingOptions.getDefaultInstance().getService();
+
+    // The name of the log to write to
+    String logName = args[0];  // "my-log";
+
+    // The data to write to the log
+    String text = "Hello, world!";
+
+    LogEntry entry = LogEntry.newBuilder(StringPayload.of(text))
+        .setSeverity(Severity.ERROR)
+        .setLogName(logName)
+        .setResource(MonitoredResource.newBuilder("global").build())
+        .build();
+
+    // Writes the log entry asynchronously
+    logging.write(Collections.singleton(entry));
+
+    System.out.printf("Logged: %s%n", text);
+  }
+}
+// [END logging_quickstart]

--- a/samples/snippets/src/main/java/com/example/logging/QuickstartSample.java
+++ b/samples/snippets/src/main/java/com/example/logging/QuickstartSample.java
@@ -26,32 +26,33 @@ import com.google.cloud.logging.Severity;
 import java.util.Collections;
 
 /**
- * This sample demonstrates writing logs using the Stackdriver Logging API.
- * The library also offers a java.util.logging Handler `com.google.cloud.logging.LoggingHandler`
- * Logback integration is also available :
+ * This sample demonstrates writing logs using the Stackdriver Logging API. The library also offers
+ * a java.util.logging Handler `com.google.cloud.logging.LoggingHandler` Logback integration is also
+ * available :
  * https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-contrib/google-cloud-logging-logback
  * Using the java.util.logging handler / Logback appender should be preferred to using the API
  * directly.
  */
 public class QuickstartSample {
 
-  /** Expects a new or existing Stackdriver log name as the first argument.*/
+  /** Expects a new or existing Stackdriver log name as the first argument. */
   public static void main(String... args) throws Exception {
 
     // Instantiates a client
     Logging logging = LoggingOptions.getDefaultInstance().getService();
 
     // The name of the log to write to
-    String logName = args[0];  // "my-log";
+    String logName = args[0]; // "my-log";
 
     // The data to write to the log
     String text = "Hello, world!";
 
-    LogEntry entry = LogEntry.newBuilder(StringPayload.of(text))
-        .setSeverity(Severity.ERROR)
-        .setLogName(logName)
-        .setResource(MonitoredResource.newBuilder("global").build())
-        .build();
+    LogEntry entry =
+        LogEntry.newBuilder(StringPayload.of(text))
+            .setSeverity(Severity.ERROR)
+            .setLogName(logName)
+            .setResource(MonitoredResource.newBuilder("global").build())
+            .build();
 
     // Writes the log entry asynchronously
     logging.write(Collections.singleton(entry));

--- a/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
+++ b/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.logging;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.MonitoredResource;
+import com.google.cloud.logging.LogEntry;
+import com.google.cloud.logging.Logging;
+import com.google.cloud.logging.LoggingOptions;
+import com.google.cloud.logging.Payload.StringPayload;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Collections;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for quickstart sample.
+ */
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
+public class LoggingIT {
+
+  private static final String QUICKSTART_LOG = "my-log";
+  private static final String TEST_WRITE_LOG = "test-log";
+
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private Logging logging = LoggingOptions.getDefaultInstance().getService();
+
+  private void deleteLog(String logName) {
+    logging.deleteLog(logName);
+  }
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    // Clean up created logs
+    deleteLog(QUICKSTART_LOG);
+    deleteLog(TEST_WRITE_LOG);
+
+    System.setOut(null);
+  }
+
+  @Test
+  public void testQuickstart() throws Exception {
+    QuickstartSample.main(QUICKSTART_LOG);
+    String got = bout.toString();
+    assertThat(got).contains("Logged: Hello, world!");
+  }
+
+  @Test(timeout = 60000)
+  public void testWriteAndListLogs() throws Exception {
+    // write a log entry
+    LogEntry entry = LogEntry.newBuilder(StringPayload.of("Hello world again"))
+        .setLogName(TEST_WRITE_LOG)
+        .setResource(MonitoredResource.newBuilder("global").build())
+        .build();
+    logging.write(Collections.singleton(entry));
+    // flush out log immediately
+    logging.flush();
+    bout.reset();
+    // Check if the log is listed yet
+    while (bout.toString().isEmpty()) {
+      ListLogs.main(TEST_WRITE_LOG);
+      Thread.sleep(5000);
+    }
+    assertThat(bout.toString().contains("Hello world again")).isTrue();
+  }
+}

--- a/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
+++ b/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
@@ -32,9 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Tests for quickstart sample.
- */
+/** Tests for quickstart sample. */
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class LoggingIT {
@@ -76,10 +74,11 @@ public class LoggingIT {
   @Test(timeout = 60000)
   public void testWriteAndListLogs() throws Exception {
     // write a log entry
-    LogEntry entry = LogEntry.newBuilder(StringPayload.of("Hello world again"))
-        .setLogName(TEST_WRITE_LOG)
-        .setResource(MonitoredResource.newBuilder("global").build())
-        .build();
+    LogEntry entry =
+        LogEntry.newBuilder(StringPayload.of("Hello world again"))
+            .setLogName(TEST_WRITE_LOG)
+            .setResource(MonitoredResource.newBuilder("global").build())
+            .build();
     logging.write(Collections.singleton(entry));
     // flush out log immediately
     logging.flush();


### PR DESCRIPTION
This is needed to get the install snippets for cloudsite out of the README and into managed `pom.xml` files (`samples/install-with-bom/pom.xml` and `samples/install-without-bom/pom.xml`). The snippets are copied unaltered from https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/logging/cloud-client