### PR TITLE
test: split tests by resource type. fix query time by limiting by timestamp

### DIFF
--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/BaseSystemTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/BaseSystemTest.java
@@ -20,16 +20,14 @@ import com.google.api.gax.paging.Page;
 import com.google.cloud.logging.testing.RemoteLoggingHelper;
 import com.google.common.collect.Iterators;
 import com.google.logging.v2.LogName;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Iterator;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
-
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.Iterator;
 
 /**
  * A base class for system tests. This class can be extended to run system tests in different
@@ -37,8 +35,7 @@ import java.util.Iterator;
  */
 public class BaseSystemTest {
 
-  @Rule
-  public Timeout globalTimeout = Timeout.seconds(600);
+  @Rule public Timeout globalTimeout = Timeout.seconds(600);
 
   private static DateFormat RFC_3339 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 
@@ -59,18 +56,17 @@ public class BaseSystemTest {
    * Creates an equality expression for logging filter.
    *
    * @see <a href="https://cloud.google.com/logging/docs/view/advanced_filters">Advanced Logs
-   * Filters Documentation</a>
+   *     Filters Documentation</a>
    */
   protected static <V> String createEqualityFilter(String name, V value) {
     return name + " = " + "\"" + value.toString() + "\"";
   }
 
-
   /**
    * Creates an equality expression for logging filter.
    *
    * @see <a href="https://cloud.google.com/logging/docs/view/advanced_filters">Advanced Logs
-   * Filters Documentation</a>
+   *     Filters Documentation</a>
    */
   protected static String createTimestampFilter(int hoursAgo) {
     Calendar calendar = Calendar.getInstance();
@@ -78,24 +74,23 @@ public class BaseSystemTest {
     return "timestamp>=\"" + RFC_3339.format(calendar.getTime()) + "\"";
   }
 
-  /**
-   * Helper to poll for logs until they are returned by the backend.
-   */
+  /** Helper to poll for logs until they are returned by the backend. */
   protected static Iterator<LogEntry> waitForLogs(LogName logName) throws InterruptedException {
     return waitForLogs(logName, 1);
   }
 
-  /**
-   * Helper to poll for logs until they are returned by the backend.
-   */
-  protected static Iterator<LogEntry> waitForLogs(LogName logName, int minLogs) throws InterruptedException {
+  /** Helper to poll for logs until they are returned by the backend. */
+  protected static Iterator<LogEntry> waitForLogs(LogName logName, int minLogs)
+      throws InterruptedException {
     String filter = createEqualityFilter("logName", logName) + " AND " + createTimestampFilter(1);
     Logging.EntryListOption[] options = {Logging.EntryListOption.filter(filter)};
     return waitForLogs(options, minLogs);
   }
 
-  private final static DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-  protected static Iterator<LogEntry> waitForLogs(Logging.EntryListOption[] options, int minLogs) throws InterruptedException {
+  private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+  protected static Iterator<LogEntry> waitForLogs(Logging.EntryListOption[] options, int minLogs)
+      throws InterruptedException {
     Page<LogEntry> page = logging.listLogEntries(options);
     while (Iterators.size(page.iterateAll().iterator()) < minLogs) {
       Thread.sleep(500);

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/BaseSystemTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/BaseSystemTest.java
@@ -16,368 +16,91 @@
 
 package com.google.cloud.logging;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import com.google.api.gax.paging.Page;
-import com.google.cloud.MonitoredResource;
-import com.google.cloud.MonitoredResourceDescriptor;
-import com.google.cloud.logging.Logging.EntryListOption;
-import com.google.cloud.logging.Logging.SortingField;
-import com.google.cloud.logging.Logging.SortingOrder;
-import com.google.cloud.logging.Payload.JsonPayload;
-import com.google.cloud.logging.Payload.StringPayload;
-import com.google.cloud.logging.SinkInfo.Destination.DatasetDestination;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import com.google.cloud.logging.testing.RemoteLoggingHelper;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Sets;
 import com.google.logging.v2.LogName;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.rules.Timeout;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Iterator;
 
 /**
  * A base class for system tests. This class can be extended to run system tests in different
  * environments (e.g. local emulator or remote Logging service).
  */
-public abstract class BaseSystemTest {
+public class BaseSystemTest {
 
-  @Rule public Timeout globalTimeout = Timeout.seconds(600);
+  @Rule
+  public Timeout globalTimeout = Timeout.seconds(600);
 
-  /**
-   * Returns the Logging service used to issue requests. This service can be such that it interacts
-   * with the remote Logging service (for integration tests) or with an emulator (for local
-   * testing).
-   */
-  protected abstract Logging logging();
+  private static DateFormat RFC_3339 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 
-  /**
-   * Formats a resource name for testing purpose. For instance, for tests against the remote
-   * service, it is recommended to append to the name a random or time-based seed to prevent name
-   * clashes.
-   */
-  protected abstract String formatForTest(String resourceName);
+  protected static Logging logging;
+
+  @BeforeClass
+  public static void beforeClass() {
+    RemoteLoggingHelper helper = RemoteLoggingHelper.create();
+    logging = helper.getOptions().getService();
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    logging.close();
+  }
 
   /**
    * Creates an equality expression for logging filter.
    *
    * @see <a href="https://cloud.google.com/logging/docs/view/advanced_filters">Advanced Logs
-   *     Filters Documentation</a>
+   * Filters Documentation</a>
    */
-  static <V> String createEqualityFilter(String name, V value) {
+  protected static <V> String createEqualityFilter(String name, V value) {
     return name + " = " + "\"" + value.toString() + "\"";
   }
 
-  @Test
-  public void testCreateGetUpdateAndDeleteSink() {
-    String name = formatForTest("test-create-get-update-sink");
-    SinkInfo sinkInfo =
-        SinkInfo.newBuilder(name, DatasetDestination.of("dataset"))
-            .setFilter("severity>=ERROR")
-            .setVersionFormat(SinkInfo.VersionFormat.V2)
-            .build();
-    Sink sink = logging().create(sinkInfo);
-    assertEquals(name, sink.getName());
-    assertEquals(SinkInfo.VersionFormat.V2, sink.getVersionFormat());
-    assertEquals("severity>=ERROR", sink.getFilter());
-    DatasetDestination datasetDestination = sink.getDestination();
-    assertEquals(logging().getOptions().getProjectId(), datasetDestination.getProject());
-    assertEquals("dataset", datasetDestination.getDataset());
-    assertEquals(sink, logging().getSink(name));
-    sink = sink.toBuilder().setFilter("severity<=ERROR").build().update();
-    assertEquals(name, sink.getName());
-    assertEquals(SinkInfo.VersionFormat.V2, sink.getVersionFormat());
-    assertEquals("severity<=ERROR", sink.getFilter());
-    assertTrue(sink.delete());
-    assertFalse(sink.delete());
+
+  /**
+   * Creates an equality expression for logging filter.
+   *
+   * @see <a href="https://cloud.google.com/logging/docs/view/advanced_filters">Advanced Logs
+   * Filters Documentation</a>
+   */
+  protected static String createTimestampFilter(int hoursAgo) {
+    Calendar calendar = Calendar.getInstance();
+    calendar.add(Calendar.HOUR, -1 * hoursAgo);
+    return "timestamp>=\"" + RFC_3339.format(calendar.getTime()) + "\"";
   }
 
-  @Test
-  public void testUpdateNonExistingSink() {
-    String name = formatForTest("test-update-non-existing-sink");
-    SinkInfo sinkInfo =
-        SinkInfo.newBuilder(name, DatasetDestination.of("dataset"))
-            .setFilter("severity>=ERROR")
-            .setVersionFormat(SinkInfo.VersionFormat.V2)
-            .build();
-    assertNull(logging().getSink(name));
-    try {
-      logging().update(sinkInfo);
-      fail();
-    } catch (LoggingException expected) {
-      assertNotNull(expected.getMessage());
-    }
+  /**
+   * Helper to poll for logs until they are returned by the backend.
+   */
+  protected static Iterator<LogEntry> waitForLogs(LogName logName) throws InterruptedException {
+    return waitForLogs(logName, 1);
   }
 
-  @Test
-  public void testListSinks() throws InterruptedException {
-    String firstName = formatForTest("test-list-sinks-1");
-    String secondName = formatForTest("test-list-sinks-2");
-    Sink firstSink = logging().create(SinkInfo.of(firstName, DatasetDestination.of("dataset")));
-    Sink secondSink = logging().create(SinkInfo.of(secondName, DatasetDestination.of("dataset")));
-    Logging.ListOption[] options = {Logging.ListOption.pageSize(1)};
-    Page<Sink> sinkPage = logging().listSinks(options);
-    Set<Sink> sinks = Sets.newHashSet(sinkPage.iterateAll());
-    while (!sinks.contains(firstSink) || !sinks.contains(secondSink)) {
+  /**
+   * Helper to poll for logs until they are returned by the backend.
+   */
+  protected static Iterator<LogEntry> waitForLogs(LogName logName, int minLogs) throws InterruptedException {
+    String filter = createEqualityFilter("logName", logName) + " AND " + createTimestampFilter(1);
+    Logging.EntryListOption[] options = {Logging.EntryListOption.filter(filter)};
+    return waitForLogs(options, minLogs);
+  }
+
+  private final static DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+  protected static Iterator<LogEntry> waitForLogs(Logging.EntryListOption[] options, int minLogs) throws InterruptedException {
+    Page<LogEntry> page = logging.listLogEntries(options);
+    while (Iterators.size(page.iterateAll().iterator()) < minLogs) {
       Thread.sleep(500);
-      sinks = Sets.newHashSet(logging().listSinks(options).iterateAll());
+      page = logging.listLogEntries(options);
     }
-    firstSink.delete();
-    secondSink.delete();
-  }
-
-  @Test
-  public void testListMonitoredResourceDescriptors() {
-    Iterator<MonitoredResourceDescriptor> iterator =
-        logging()
-            .listMonitoredResourceDescriptors(Logging.ListOption.pageSize(100))
-            .iterateAll()
-            .iterator();
-    int count = 0;
-    while (iterator.hasNext()) {
-      assertNotNull(iterator.next().getType());
-      count += 1;
-    }
-    assertTrue(count > 0);
-  }
-
-  @Test
-  public void testCreateGetUpdateAndDeleteMetric() {
-    String name = formatForTest("test-create-get-update-metric");
-    MetricInfo metricInfo =
-        MetricInfo.newBuilder(name, "severity>=ERROR").setDescription("description").build();
-    Metric metric = logging().create(metricInfo);
-    assertEquals(name, metric.getName());
-    assertEquals("severity>=ERROR", metric.getFilter());
-    assertEquals("description", metric.getDescription());
-    assertEquals(metric, logging().getMetric(name));
-    metric =
-        metric
-            .toBuilder()
-            .setDescription("newDescription")
-            .setFilter("severity>=WARNING")
-            .build()
-            .update();
-    assertEquals(name, metric.getName());
-    assertEquals("severity>=WARNING", metric.getFilter());
-    assertEquals("newDescription", metric.getDescription());
-    assertTrue(metric.delete());
-    assertFalse(metric.delete());
-  }
-
-  @Test
-  public void testUpdateNonExistingMetric() {
-    String name = formatForTest("test-update-non-existing-metric");
-    MetricInfo metricInfo =
-        MetricInfo.newBuilder(name, "severity>=ERROR").setDescription("description").build();
-    assertNull(logging().getMetric(name));
-    Metric metric = logging().update(metricInfo);
-    assertEquals(name, metric.getName());
-    assertEquals("severity>=ERROR", metric.getFilter());
-    assertEquals("description", metric.getDescription());
-    assertTrue(metric.delete());
-  }
-
-  @Test
-  public void testListMetrics() throws InterruptedException {
-    String firstName = formatForTest("test-list-metrics-1");
-    String secondName = formatForTest("test-list-metrics-2");
-    Metric firstMetric = logging().create(MetricInfo.of(firstName, "severity>=ERROR"));
-    Metric secondMetric = logging().create(MetricInfo.of(secondName, "severity>=ERROR"));
-    Logging.ListOption[] options = {Logging.ListOption.pageSize(1)};
-    Page<Metric> metricPage = logging().listMetrics(options);
-    Set<Metric> metrics = Sets.newHashSet(metricPage.iterateAll());
-    while (!metrics.contains(firstMetric) || !metrics.contains(secondMetric)) {
-      Thread.sleep(500);
-      metrics = Sets.newHashSet(logging().listMetrics(options).iterateAll());
-    }
-    firstMetric.delete();
-    secondMetric.delete();
-  }
-
-  @Test
-  public void testWriteAndListLogEntries() throws InterruptedException {
-    String logId = formatForTest("test-write-log-entries-log");
-    LoggingOptions loggingOptions = logging().getOptions();
-    LogName logName = LogName.ofProjectLogName(loggingOptions.getProjectId(), logId);
-    StringPayload firstPayload = StringPayload.of("stringPayload");
-    LogEntry firstEntry =
-        LogEntry.newBuilder(firstPayload)
-            .addLabel("key1", "value1")
-            .setLogName(logId)
-            .setHttpRequest(HttpRequest.newBuilder().setStatus(500).build())
-            .setResource(MonitoredResource.newBuilder("global").build())
-            .build();
-    JsonPayload secondPayload =
-        JsonPayload.of(ImmutableMap.<String, Object>of("jsonKey", "jsonValue"));
-    LogEntry secondEntry =
-        LogEntry.newBuilder(secondPayload)
-            .addLabel("key2", "value2")
-            .setLogName(logId)
-            .setOperation(Operation.of("operationId", "operationProducer"))
-            .setResource(MonitoredResource.newBuilder("cloudsql_database").build())
-            .build();
-    logging().write(ImmutableList.of(firstEntry));
-    logging().write(ImmutableList.of(secondEntry));
-    logging().flush();
-    String filter = createEqualityFilter("logName", logName);
-    EntryListOption[] options = {EntryListOption.filter(filter), EntryListOption.pageSize(1)};
-    Page<LogEntry> page = logging().listLogEntries(options);
-    while (Iterators.size(page.iterateAll().iterator()) < 2) {
-      Thread.sleep(500);
-      page = logging().listLogEntries(options);
-    }
-    Iterator<LogEntry> iterator = page.iterateAll().iterator();
-    assertTrue(iterator.hasNext());
-    LogEntry entry = iterator.next();
-    assertEquals(firstPayload, entry.getPayload());
-    assertEquals(logId, entry.getLogName());
-    assertEquals(ImmutableMap.of("key1", "value1"), entry.getLabels());
-    assertEquals("global", entry.getResource().getType());
-    assertEquals(HttpRequest.newBuilder().setStatus(500).build(), entry.getHttpRequest());
-    assertEquals(Severity.DEFAULT, entry.getSeverity());
-    assertNull(entry.getOperation());
-    assertNotNull(entry.getInsertId());
-    assertNotNull(entry.getTimestamp());
-    assertTrue(iterator.hasNext());
-    entry = iterator.next();
-    assertEquals(secondPayload, entry.getPayload());
-    assertEquals(logId, entry.getLogName());
-    assertEquals(ImmutableMap.of("key2", "value2"), entry.getLabels());
-    assertEquals("cloudsql_database", entry.getResource().getType());
-    assertEquals(Operation.of("operationId", "operationProducer"), entry.getOperation());
-    assertEquals(Severity.DEFAULT, entry.getSeverity());
-    assertNull(entry.getHttpRequest());
-    assertNotNull(entry.getInsertId());
-    assertNotNull(entry.getTimestamp());
-    options =
-        new EntryListOption[] {
-          EntryListOption.filter(filter),
-          EntryListOption.sortOrder(SortingField.TIMESTAMP, SortingOrder.DESCENDING)
-        };
-    page = logging().listLogEntries(options);
-    while (Iterators.size(page.iterateAll().iterator()) < 2) {
-      Thread.sleep(500);
-      page = logging().listLogEntries(options);
-    }
-    iterator = page.iterateAll().iterator();
-    Long lastTimestamp = iterator.next().getTimestamp();
-    while (iterator.hasNext()) {
-      assertTrue(iterator.next().getTimestamp() <= lastTimestamp);
-    }
-    int deleteAttempts = 0;
-    int allowedDeleteAttempts = 5;
-    boolean deleted = false;
-    while (!deleted && deleteAttempts < allowedDeleteAttempts) {
-      Thread.sleep(5000);
-      deleted = logging().deleteLog(logId);
-      deleteAttempts++;
-    }
-    assertTrue(deleted);
-  }
-
-  @Test
-  public void testDeleteNonExistingLog() {
-    String logId = formatForTest("test-delete-non-existing-log");
-    assertFalse(logging().deleteLog(logId));
-  }
-
-  @Test
-  public void testLoggingHandler() throws InterruptedException {
-    String logId = formatForTest("test-logging-handler");
-    LoggingOptions options = logging().getOptions();
-    LogName logName = LogName.ofProjectLogName(options.getProjectId(), logId);
-    LoggingHandler handler = new LoggingHandler(logId, options);
-    handler.setLevel(Level.INFO);
-    Logger logger = Logger.getLogger(getClass().getName());
-    logger.addHandler(handler);
-    logger.setLevel(Level.INFO);
-    logger.info("Message");
-    String filter = createEqualityFilter("logName", logName);
-    Iterator<LogEntry> iterator =
-        logging().listLogEntries(EntryListOption.filter(filter)).iterateAll().iterator();
-    while (!iterator.hasNext()) {
-      Thread.sleep(500L);
-      iterator = logging().listLogEntries(EntryListOption.filter(filter)).iterateAll().iterator();
-    }
-    assertThat(iterator.hasNext()).isTrue();
-    LogEntry entry = iterator.next();
-    assertThat(entry.getPayload() instanceof StringPayload).isTrue();
-    assertThat(entry.<StringPayload>getPayload().getData()).contains("Message");
-    assertThat(entry.getLogName()).isEqualTo(logId);
-    assertThat(entry.getLabels())
-        .containsExactly("levelName", "INFO", "levelValue", String.valueOf(Level.INFO.intValue()));
-    MonitoredResource monitoredResource =
-        new LoggingConfig(handler.getClass().getName())
-            .getMonitoredResource(options.getProjectId());
-    assertThat(entry.getResource().getType()).isEqualTo(monitoredResource.getType());
-    assertThat(entry.getResource().getLabels()).containsEntry("project_id", options.getProjectId());
-    assertThat(entry.getHttpRequest()).isNull();
-    assertThat(entry.getSeverity()).isEqualTo(Severity.INFO);
-    assertThat(entry.getOperation()).isNull();
-    assertThat(entry.getInsertId()).isNotNull();
-    assertThat(entry.getTimestamp()).isNotNull();
-    assertThat(iterator.hasNext()).isFalse();
-    logger.removeHandler(handler);
-    logging().deleteLog(logId);
-  }
-
-  @Test
-  public void testSyncLoggingHandler() throws InterruptedException {
-    String logId = formatForTest("test-sync-logging-handler");
-    LoggingOptions options = logging().getOptions();
-    LogName logName = LogName.ofProjectLogName(options.getProjectId(), logId);
-    MonitoredResource resource =
-        MonitoredResource.of(
-            "gce_instance",
-            ImmutableMap.of(
-                "project_id",
-                options.getProjectId(),
-                "instance_id",
-                "instance",
-                "zone",
-                "us-central1-a"));
-    LoggingHandler handler = new LoggingHandler(logId, options, resource);
-    handler.setLevel(Level.WARNING);
-    handler.setSynchronicity(Synchronicity.SYNC);
-    Logger logger = Logger.getLogger(getClass().getName());
-    logger.addHandler(handler);
-    logger.setLevel(Level.WARNING);
-    logger.warning("Message");
-    String filter = createEqualityFilter("logName", logName);
-    Iterator<LogEntry> iterator =
-        logging().listLogEntries(EntryListOption.filter(filter)).iterateAll().iterator();
-    while (!iterator.hasNext()) {
-      Thread.sleep(500L);
-      iterator = logging().listLogEntries(EntryListOption.filter(filter)).iterateAll().iterator();
-    }
-    assertTrue(iterator.hasNext());
-    LogEntry entry = iterator.next();
-    assertTrue(entry.getPayload() instanceof StringPayload);
-    assertTrue(entry.<StringPayload>getPayload().getData().contains("Message"));
-    assertEquals(logId, entry.getLogName());
-    assertEquals(
-        ImmutableMap.of(
-            "levelName", "WARNING", "levelValue", String.valueOf(Level.WARNING.intValue())),
-        entry.getLabels());
-    assertEquals(resource, entry.getResource());
-    assertNull(entry.getHttpRequest());
-    assertEquals(Severity.WARNING, entry.getSeverity());
-    assertNull(entry.getOperation());
-    assertNotNull(entry.getInsertId());
-    assertNotNull(entry.getTimestamp());
-    assertFalse(iterator.hasNext());
-    logger.removeHandler(handler);
-    logging().deleteLog(logId);
+    return page.iterateAll().iterator();
   }
 }

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITJulLoggerTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITJulLoggerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging.it;
+
+import com.google.cloud.MonitoredResource;
+import com.google.cloud.logging.BaseSystemTest;
+import com.google.cloud.logging.LogEntry;
+import com.google.cloud.logging.LoggingHandler;
+import com.google.cloud.logging.LoggingOptions;
+import com.google.cloud.logging.Payload;
+import com.google.cloud.logging.Severity;
+import com.google.cloud.logging.Synchronicity;
+import com.google.common.collect.ImmutableMap;
+import com.google.logging.v2.LogName;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ITJulLoggerTest extends BaseSystemTest {
+
+  @Test
+  public void testLoggingHandler() throws InterruptedException {
+    String logId = formatForTest("test-logging-handler");
+    LoggingOptions options = logging.getOptions();
+    LogName logName = LogName.ofProjectLogName(options.getProjectId(), logId);
+
+    // Create a jul logger at with INFO level
+    LoggingHandler handler = new LoggingHandler(logId, options);
+    handler.setLevel(Level.INFO);
+    Logger logger = Logger.getLogger(getClass().getName());
+    logger.addHandler(handler);
+    logger.setLevel(Level.INFO);
+
+    // log a test message
+    logger.info("Message");
+
+    // Find the log name and wait until we have at least 1 entry
+    Iterator<LogEntry> iterator = waitForLogs(logName);
+    assertThat(iterator.hasNext()).isTrue();
+
+    // Read the log entry
+    LogEntry entry = iterator.next();
+    assertThat(entry.getPayload() instanceof Payload.StringPayload).isTrue();
+    assertThat(entry.<Payload.StringPayload>getPayload().getData()).contains("Message");
+    assertThat(entry.getLogName()).isEqualTo(logId);
+    assertThat(entry.getLabels())
+        .containsExactly("levelName", "INFO", "levelValue", String.valueOf(Level.INFO.intValue()));
+
+    assertThat(entry.getResource().getLabels()).containsEntry("project_id", options.getProjectId());
+    assertThat(entry.getHttpRequest()).isNull();
+    assertThat(entry.getSeverity()).isEqualTo(Severity.INFO);
+    assertThat(entry.getOperation()).isNull();
+    assertThat(entry.getInsertId()).isNotNull();
+    assertThat(entry.getTimestamp()).isNotNull();
+    assertThat(iterator.hasNext()).isFalse();
+    logger.removeHandler(handler);
+    logging.deleteLog(logId);
+  }
+
+  @Test
+  public void testSyncLoggingHandler() throws InterruptedException {
+    String logId = formatForTest("test-sync-logging-handler");
+    LoggingOptions options = logging.getOptions();
+    LogName logName = LogName.ofProjectLogName(options.getProjectId(), logId);
+    MonitoredResource resource =
+        MonitoredResource.of(
+            "gce_instance",
+            ImmutableMap.of(
+                "project_id",
+                options.getProjectId(),
+                "instance_id",
+                "instance",
+                "zone",
+                "us-central1-a"));
+
+    // Create a jul logger at with INFO level
+    LoggingHandler handler = new LoggingHandler(logId, options, resource);
+    handler.setLevel(Level.WARNING);
+    handler.setSynchronicity(Synchronicity.SYNC);
+    Logger logger = Logger.getLogger(getClass().getName());
+    logger.addHandler(handler);
+    logger.setLevel(Level.WARNING);
+    logger.warning("Message");
+
+    // Find the log name and wait until we have at least 1 entry
+    Iterator<LogEntry> iterator = waitForLogs(logName);
+    assertThat(iterator.hasNext()).isTrue();
+
+    // Read the log entry
+    LogEntry entry = iterator.next();
+    assertTrue(entry.getPayload() instanceof Payload.StringPayload);
+    assertTrue(entry.<Payload.StringPayload>getPayload().getData().contains("Message"));
+    assertEquals(logId, entry.getLogName());
+    assertEquals(
+        ImmutableMap.of(
+            "levelName", "WARNING", "levelValue", String.valueOf(Level.WARNING.intValue())),
+        entry.getLabels());
+    assertEquals(resource, entry.getResource());
+    assertNull(entry.getHttpRequest());
+    assertEquals(Severity.WARNING, entry.getSeverity());
+    assertNull(entry.getOperation());
+    assertNotNull(entry.getInsertId());
+    assertNotNull(entry.getTimestamp());
+    assertFalse(iterator.hasNext());
+    logger.removeHandler(handler);
+    logging.deleteLog(logId);
+  }
+}

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITJulLoggerTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITJulLoggerTest.java
@@ -16,6 +16,14 @@
 
 package com.google.cloud.logging.it;
 
+import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import com.google.cloud.MonitoredResource;
 import com.google.cloud.logging.BaseSystemTest;
 import com.google.cloud.logging.LogEntry;
@@ -26,19 +34,10 @@ import com.google.cloud.logging.Severity;
 import com.google.cloud.logging.Synchronicity;
 import com.google.common.collect.ImmutableMap;
 import com.google.logging.v2.LogName;
-import org.junit.Test;
-
 import java.util.Iterator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class ITJulLoggerTest extends BaseSystemTest {
 

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITLoggingTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITLoggingTest.java
@@ -36,7 +36,11 @@ import java.util.Iterator;
 
 import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ITLoggingTest extends BaseSystemTest {
 

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITLoggingTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITLoggingTest.java
@@ -16,6 +16,14 @@
 
 package com.google.cloud.logging.it;
 
+import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import com.google.cloud.MonitoredResource;
 import com.google.cloud.logging.BaseSystemTest;
 import com.google.cloud.logging.HttpRequest;
@@ -28,25 +36,17 @@ import com.google.cloud.logging.Severity;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.logging.v2.LogName;
+import java.util.Iterator;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.Iterator;
-
-import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 public class ITLoggingTest extends BaseSystemTest {
 
-  private final static String LOG_ID = formatForTest("test-write-log-entries-log");
-  private final static Payload.StringPayload FIRST_PAYLOAD = Payload.StringPayload.of("stringPayload");
-  private final static Payload.JsonPayload SECOND_PAYLOAD =
+  private static final String LOG_ID = formatForTest("test-write-log-entries-log");
+  private static final Payload.StringPayload FIRST_PAYLOAD =
+      Payload.StringPayload.of("stringPayload");
+  private static final Payload.JsonPayload SECOND_PAYLOAD =
       Payload.JsonPayload.of(ImmutableMap.<String, Object>of("jsonKey", "jsonValue"));
 
   @BeforeClass
@@ -125,8 +125,9 @@ public class ITLoggingTest extends BaseSystemTest {
     String filter = createEqualityFilter("logName", logName) + " AND " + createTimestampFilter(1);
     Logging.EntryListOption[] options =
         new Logging.EntryListOption[] {
-            Logging.EntryListOption.filter(filter),
-            Logging.EntryListOption.sortOrder(Logging.SortingField.TIMESTAMP, Logging.SortingOrder.DESCENDING)
+          Logging.EntryListOption.filter(filter),
+          Logging.EntryListOption.sortOrder(
+              Logging.SortingField.TIMESTAMP, Logging.SortingOrder.DESCENDING)
         };
     Iterator<LogEntry> iterator = waitForLogs(options, 2);
 

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITLoggingTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITLoggingTest.java
@@ -16,38 +16,125 @@
 
 package com.google.cloud.logging.it;
 
+import com.google.cloud.MonitoredResource;
 import com.google.cloud.logging.BaseSystemTest;
+import com.google.cloud.logging.HttpRequest;
+import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
-import com.google.cloud.logging.testing.RemoteLoggingHelper;
+import com.google.cloud.logging.LoggingOptions;
+import com.google.cloud.logging.Operation;
+import com.google.cloud.logging.Payload;
+import com.google.cloud.logging.Severity;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.logging.v2.LogName;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.rules.Timeout;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.*;
 
 public class ITLoggingTest extends BaseSystemTest {
 
-  @Rule public Timeout globalTimeout = Timeout.seconds(300);
-
-  private static Logging logging;
+  private final static String LOG_ID = formatForTest("test-write-log-entries-log");
+  private final static Payload.StringPayload FIRST_PAYLOAD = Payload.StringPayload.of("stringPayload");
+  private final static Payload.JsonPayload SECOND_PAYLOAD =
+      Payload.JsonPayload.of(ImmutableMap.<String, Object>of("jsonKey", "jsonValue"));
 
   @BeforeClass
-  public static void beforeClass() {
-    RemoteLoggingHelper helper = RemoteLoggingHelper.create();
-    logging = helper.getOptions().getService();
+  public static void insertLogs() {
+    LogEntry firstEntry =
+        LogEntry.newBuilder(FIRST_PAYLOAD)
+            .addLabel("key1", "value1")
+            .setLogName(LOG_ID)
+            .setHttpRequest(HttpRequest.newBuilder().setStatus(500).build())
+            .setResource(MonitoredResource.newBuilder("global").build())
+            .build();
+
+    LogEntry secondEntry =
+        LogEntry.newBuilder(SECOND_PAYLOAD)
+            .addLabel("key2", "value2")
+            .setLogName(LOG_ID)
+            .setOperation(Operation.of("operationId", "operationProducer"))
+            .setResource(MonitoredResource.newBuilder("cloudsql_database").build())
+            .build();
+    logging.write(ImmutableList.of(firstEntry));
+    logging.write(ImmutableList.of(secondEntry));
+    logging.flush();
   }
 
   @AfterClass
-  public static void afterClass() throws Exception {
-    logging.close();
+  public static void cleanUpLogs() throws InterruptedException {
+    int deleteAttempts = 0;
+    int allowedDeleteAttempts = 5;
+    boolean deleted = false;
+    while (!deleted && deleteAttempts < allowedDeleteAttempts) {
+      Thread.sleep(5000);
+      deleted = logging.deleteLog(LOG_ID);
+      deleteAttempts++;
+    }
+    assertTrue(deleted);
   }
 
-  @Override
-  protected Logging logging() {
-    return logging;
+  @Test(timeout = 600_000) // Note: it can take ~10 minutes for logs to propagate!
+  public void testListEntries() throws InterruptedException {
+    LoggingOptions loggingOptions = logging.getOptions();
+    LogName logName = LogName.ofProjectLogName(loggingOptions.getProjectId(), LOG_ID);
+
+    // Find the log name and wait until we have at least 2 entries
+    Iterator<LogEntry> iterator = waitForLogs(logName, 2);
+    assertThat(iterator.hasNext()).isTrue();
+
+    LogEntry entry = iterator.next();
+    assertEquals(FIRST_PAYLOAD, entry.getPayload());
+    assertEquals(LOG_ID, entry.getLogName());
+    assertEquals(ImmutableMap.of("key1", "value1"), entry.getLabels());
+    assertEquals("global", entry.getResource().getType());
+    assertEquals(HttpRequest.newBuilder().setStatus(500).build(), entry.getHttpRequest());
+    assertEquals(Severity.DEFAULT, entry.getSeverity());
+    assertNull(entry.getOperation());
+    assertNotNull(entry.getInsertId());
+    assertNotNull(entry.getTimestamp());
+    assertTrue(iterator.hasNext());
+
+    entry = iterator.next();
+    assertEquals(SECOND_PAYLOAD, entry.getPayload());
+    assertEquals(LOG_ID, entry.getLogName());
+    assertEquals(ImmutableMap.of("key2", "value2"), entry.getLabels());
+    assertEquals("cloudsql_database", entry.getResource().getType());
+    assertEquals(Operation.of("operationId", "operationProducer"), entry.getOperation());
+    assertEquals(Severity.DEFAULT, entry.getSeverity());
+    assertNull(entry.getHttpRequest());
+    assertNotNull(entry.getInsertId());
+    assertNotNull(entry.getTimestamp());
   }
 
-  @Override
-  protected String formatForTest(String resourceName) {
-    return RemoteLoggingHelper.formatForTest(resourceName);
+  @Test(timeout = 600_000) // Note: it can take ~10 minutes for logs to propagate!
+  public void testSortedOrder() throws InterruptedException {
+    LoggingOptions loggingOptions = logging.getOptions();
+    LogName logName = LogName.ofProjectLogName(loggingOptions.getProjectId(), LOG_ID);
+
+    String filter = createEqualityFilter("logName", logName) + " AND " + createTimestampFilter(1);
+    Logging.EntryListOption[] options =
+        new Logging.EntryListOption[] {
+            Logging.EntryListOption.filter(filter),
+            Logging.EntryListOption.sortOrder(Logging.SortingField.TIMESTAMP, Logging.SortingOrder.DESCENDING)
+        };
+    Iterator<LogEntry> iterator = waitForLogs(options, 2);
+
+    Long lastTimestamp = iterator.next().getTimestamp();
+    while (iterator.hasNext()) {
+      assertTrue(iterator.next().getTimestamp() <= lastTimestamp);
+    }
+  }
+
+  @Test
+  public void testDeleteNonExistingLog() {
+    String logId = formatForTest("test-delete-non-existing-log");
+    assertFalse(logging.deleteLog(logId));
   }
 }

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITMetricsTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITMetricsTest.java
@@ -31,7 +31,11 @@ import java.util.Iterator;
 import java.util.Set;
 
 import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ITMetricsTest {
 

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITMetricsTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITMetricsTest.java
@@ -16,6 +16,13 @@
 
 package com.google.cloud.logging.it;
 
+import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import com.google.api.gax.paging.Page;
 import com.google.cloud.MonitoredResourceDescriptor;
 import com.google.cloud.logging.Logging;
@@ -23,19 +30,11 @@ import com.google.cloud.logging.Metric;
 import com.google.cloud.logging.MetricInfo;
 import com.google.cloud.logging.testing.RemoteLoggingHelper;
 import com.google.common.collect.Sets;
+import java.util.Iterator;
+import java.util.Set;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.util.Iterator;
-import java.util.Set;
-
-import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 public class ITMetricsTest {
 

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITMetricsTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITMetricsTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging.it;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.MonitoredResourceDescriptor;
+import com.google.cloud.logging.Logging;
+import com.google.cloud.logging.Metric;
+import com.google.cloud.logging.MetricInfo;
+import com.google.cloud.logging.testing.RemoteLoggingHelper;
+import com.google.common.collect.Sets;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
+import static org.junit.Assert.*;
+
+public class ITMetricsTest {
+
+  private static Logging logging;
+
+  @BeforeClass
+  public static void beforeClass() {
+    RemoteLoggingHelper helper = RemoteLoggingHelper.create();
+    logging = helper.getOptions().getService();
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    logging.close();
+  }
+
+  @Test
+  public void testListMonitoredResourceDescriptors() {
+    Iterator<MonitoredResourceDescriptor> iterator =
+        logging
+            .listMonitoredResourceDescriptors(Logging.ListOption.pageSize(100))
+            .iterateAll()
+            .iterator();
+    int count = 0;
+    while (iterator.hasNext()) {
+      assertNotNull(iterator.next().getType());
+      count += 1;
+    }
+    assertTrue(count > 0);
+  }
+
+  @Test
+  public void testCreateGetUpdateAndDeleteMetric() {
+    String name = formatForTest("test-create-get-update-metric");
+    MetricInfo metricInfo =
+        MetricInfo.newBuilder(name, "severity>=ERROR").setDescription("description").build();
+    Metric metric = logging.create(metricInfo);
+    assertEquals(name, metric.getName());
+    assertEquals("severity>=ERROR", metric.getFilter());
+    assertEquals("description", metric.getDescription());
+    assertEquals(metric, logging.getMetric(name));
+    metric =
+        metric
+            .toBuilder()
+            .setDescription("newDescription")
+            .setFilter("severity>=WARNING")
+            .build()
+            .update();
+    assertEquals(name, metric.getName());
+    assertEquals("severity>=WARNING", metric.getFilter());
+    assertEquals("newDescription", metric.getDescription());
+    assertTrue(metric.delete());
+    assertFalse(metric.delete());
+  }
+
+  @Test
+  public void testUpdateNonExistingMetric() {
+    String name = formatForTest("test-update-non-existing-metric");
+    MetricInfo metricInfo =
+        MetricInfo.newBuilder(name, "severity>=ERROR").setDescription("description").build();
+    assertNull(logging.getMetric(name));
+    Metric metric = logging.update(metricInfo);
+    assertEquals(name, metric.getName());
+    assertEquals("severity>=ERROR", metric.getFilter());
+    assertEquals("description", metric.getDescription());
+    assertTrue(metric.delete());
+  }
+
+  @Test
+  public void testListMetrics() throws InterruptedException {
+    String firstName = formatForTest("test-list-metrics-1");
+    String secondName = formatForTest("test-list-metrics-2");
+    Metric firstMetric = logging.create(MetricInfo.of(firstName, "severity>=ERROR"));
+    Metric secondMetric = logging.create(MetricInfo.of(secondName, "severity>=ERROR"));
+    Logging.ListOption[] options = {Logging.ListOption.pageSize(1)};
+    Page<Metric> metricPage = logging.listMetrics(options);
+    Set<Metric> metrics = Sets.newHashSet(metricPage.iterateAll());
+    while (!metrics.contains(firstMetric) || !metrics.contains(secondMetric)) {
+      Thread.sleep(500);
+      metrics = Sets.newHashSet(logging.listMetrics(options).iterateAll());
+    }
+    firstMetric.delete();
+    secondMetric.delete();
+  }
+}

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITSinkTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITSinkTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging.it;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.logging.BaseSystemTest;
+import com.google.cloud.logging.Logging;
+import com.google.cloud.logging.LoggingException;
+import com.google.cloud.logging.Sink;
+import com.google.cloud.logging.SinkInfo;
+import com.google.common.collect.Sets;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ITSinkTest extends BaseSystemTest {
+
+  @Test
+  public void testCreateGetUpdateAndDeleteSink() {
+    String name = formatForTest("test-create-get-update-sink");
+    SinkInfo sinkInfo =
+        SinkInfo.newBuilder(name, SinkInfo.Destination.DatasetDestination.of("dataset"))
+            .setFilter("severity>=ERROR")
+            .setVersionFormat(SinkInfo.VersionFormat.V2)
+            .build();
+    Sink sink = logging.create(sinkInfo);
+    assertEquals(name, sink.getName());
+    assertEquals(SinkInfo.VersionFormat.V2, sink.getVersionFormat());
+    assertEquals("severity>=ERROR", sink.getFilter());
+    SinkInfo.Destination.DatasetDestination datasetDestination = sink.getDestination();
+    assertEquals(logging.getOptions().getProjectId(), datasetDestination.getProject());
+    assertEquals("dataset", datasetDestination.getDataset());
+    assertEquals(sink, logging.getSink(name));
+    sink = sink.toBuilder().setFilter("severity<=ERROR").build().update();
+    assertEquals(name, sink.getName());
+    assertEquals(SinkInfo.VersionFormat.V2, sink.getVersionFormat());
+    assertEquals("severity<=ERROR", sink.getFilter());
+    assertTrue(sink.delete());
+    assertFalse(sink.delete());
+  }
+
+  @Test
+  public void testUpdateNonExistingSink() {
+    String name = formatForTest("test-update-non-existing-sink");
+    SinkInfo sinkInfo =
+        SinkInfo.newBuilder(name, SinkInfo.Destination.DatasetDestination.of("dataset"))
+            .setFilter("severity>=ERROR")
+            .setVersionFormat(SinkInfo.VersionFormat.V2)
+            .build();
+    assertNull(logging.getSink(name));
+    try {
+      logging.update(sinkInfo);
+      fail();
+    } catch (LoggingException expected) {
+      assertNotNull(expected.getMessage());
+    }
+  }
+
+  @Test
+  public void testListSinks() throws InterruptedException {
+    String firstName = formatForTest("test-list-sinks-1");
+    String secondName = formatForTest("test-list-sinks-2");
+    Sink firstSink = logging.create(SinkInfo.of(firstName, SinkInfo.Destination.DatasetDestination.of("dataset")));
+    Sink secondSink = logging.create(SinkInfo.of(secondName, SinkInfo.Destination.DatasetDestination.of("dataset")));
+    Logging.ListOption[] options = {Logging.ListOption.pageSize(1)};
+    Page<Sink> sinkPage = logging.listSinks(options);
+    Set<Sink> sinks = Sets.newHashSet(sinkPage.iterateAll());
+    while (!sinks.contains(firstSink) || !sinks.contains(secondSink)) {
+      Thread.sleep(500);
+      sinks = Sets.newHashSet(logging.listSinks(options).iterateAll());
+    }
+    firstSink.delete();
+    secondSink.delete();
+  }
+}

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITSinkTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITSinkTest.java
@@ -16,17 +16,6 @@
 
 package com.google.cloud.logging.it;
 
-import com.google.api.gax.paging.Page;
-import com.google.cloud.logging.BaseSystemTest;
-import com.google.cloud.logging.Logging;
-import com.google.cloud.logging.LoggingException;
-import com.google.cloud.logging.Sink;
-import com.google.cloud.logging.SinkInfo;
-import com.google.common.collect.Sets;
-import org.junit.Test;
-
-import java.util.Set;
-
 import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -34,6 +23,16 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.logging.BaseSystemTest;
+import com.google.cloud.logging.Logging;
+import com.google.cloud.logging.LoggingException;
+import com.google.cloud.logging.Sink;
+import com.google.cloud.logging.SinkInfo;
+import com.google.common.collect.Sets;
+import java.util.Set;
+import org.junit.Test;
 
 public class ITSinkTest extends BaseSystemTest {
 
@@ -82,8 +81,12 @@ public class ITSinkTest extends BaseSystemTest {
   public void testListSinks() throws InterruptedException {
     String firstName = formatForTest("test-list-sinks-1");
     String secondName = formatForTest("test-list-sinks-2");
-    Sink firstSink = logging.create(SinkInfo.of(firstName, SinkInfo.Destination.DatasetDestination.of("dataset")));
-    Sink secondSink = logging.create(SinkInfo.of(secondName, SinkInfo.Destination.DatasetDestination.of("dataset")));
+    Sink firstSink =
+        logging.create(
+            SinkInfo.of(firstName, SinkInfo.Destination.DatasetDestination.of("dataset")));
+    Sink secondSink =
+        logging.create(
+            SinkInfo.of(secondName, SinkInfo.Destination.DatasetDestination.of("dataset")));
     Logging.ListOption[] options = {Logging.ListOption.pageSize(1)};
     Page<Sink> sinkPage = logging.listSinks(options);
     Set<Sink> sinks = Sets.newHashSet(sinkPage.iterateAll());


### PR DESCRIPTION
This should reduce the time for the integration tests from ~20 minutes to ~5 minutes and should prevent the tests from timing out.

* This PR breaks the monolilthic IT test file into tests by scope (java.util.Logger implementation, metrics, sinks, and direct logging client use).
* Previously, all the tests were defined in the BaseSystemTest with a single implementation which didn't seem necessary. Now the base class has shared helper functionality for fetching logs and instantiating the logging client.
* When fetching logs, we now only look at timestamps > 1 hour ago. This speeds up the list queries from 2 minutes to seconds.