### PR TITLE
Release java-logging v1.102.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ If you are using Maven without BOM, add this to your dependencies:
 
 If you are using Gradle, add this to your dependencies
 ```Groovy
-compile 'com.google.cloud:google-cloud-logging:1.101.2'
+compile 'com.google.cloud:google-cloud-logging:1.102.0'
 ```
 If you are using SBT, add this to your dependencies
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "1.101.2"
+libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "1.102.0"
 ```
 [//]: # ({x-version-update-end})
 

--- a/google-cloud-logging-bom/pom.xml
+++ b/google-cloud-logging-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging-bom</artifactId>
-  <version>1.101.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+  <version>1.102.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   <packaging>pom</packaging>
   <parent>
     <groupId>com.google.cloud</groupId>
@@ -64,17 +64,17 @@
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-logging-v2</artifactId>
-        <version>0.84.2</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
+        <version>0.85.0</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-logging-v2</artifactId>
-        <version>0.84.2</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
+        <version>0.85.0</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-logging</artifactId>
-        <version>1.101.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+        <version>1.102.0</version><!-- {x-version-update:google-cloud-logging:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-cloud-logging/pom.xml
+++ b/google-cloud-logging/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging</artifactId>
-  <version>1.101.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+  <version>1.102.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Logging</name>
   <url>https://github.com/googleapis/java-logging</url>
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-logging-parent</artifactId>
-    <version>1.101.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+    <version>1.102.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   </parent>
   <properties>
     <site.installationModule>google-cloud-logging</site.installationModule>

--- a/grpc-google-cloud-logging-v2/pom.xml
+++ b/grpc-google-cloud-logging-v2/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>grpc-google-cloud-logging-v2</artifactId>
-  <version>0.84.2</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
+  <version>0.85.0</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
   <name>grpc-google-cloud-logging-v2</name>
   <description>GRPC library for grpc-google-cloud-logging-v2</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-logging-parent</artifactId>
-    <version>1.101.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+    <version>1.102.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.101.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+  <version>1.102.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   <name>Google Cloud Logging Parent</name>
   <url>https://github.com/googleapis/java-logging</url>
   <description>
@@ -83,17 +83,17 @@
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-logging-v2</artifactId>
-        <version>0.84.2</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
+        <version>0.85.0</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-logging-v2</artifactId>
-        <version>0.84.2</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
+        <version>0.85.0</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-logging</artifactId>
-        <version>1.101.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+        <version>1.102.0</version><!-- {x-version-update:google-cloud-logging:current} -->
       </dependency>
 
       <dependency>

--- a/proto-google-cloud-logging-v2/pom.xml
+++ b/proto-google-cloud-logging-v2/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>proto-google-cloud-logging-v2</artifactId>
-  <version>0.84.2</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
+  <version>0.85.0</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
   <name>proto-google-cloud-logging-v2</name>
   <description>PROTO library for proto-google-cloud-logging-v2</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-logging-parent</artifactId>
-    <version>1.101.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+    <version>1.102.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-logging</artifactId>
-      <version>1.101.2</version>
+      <version>1.102.0</version>
     </dependency>
     <!-- [END logging_install_without_bom] -->
   </dependencies>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-logging</artifactId>
-      <version>1.101.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+      <version>1.102.0</version><!-- {x-version-update:google-cloud-logging:current} -->
     </dependency>
   </dependencies>
 </project>

--- a/versions.txt
+++ b/versions.txt
@@ -1,6 +1,6 @@
 # Format:
 # module:released-version:current-version
 
-proto-google-cloud-logging-v2:0.84.2:0.84.2
-grpc-google-cloud-logging-v2:0.84.2:0.84.2
-google-cloud-logging:1.101.2:1.101.2
+proto-google-cloud-logging-v2:0.85.0:0.85.0
+grpc-google-cloud-logging-v2:0.85.0:0.85.0
+google-cloud-logging:1.102.0:1.102.0


### PR DESCRIPTION
This pull request was generated using releasetool.

09-03-2020 08:27 PDT

### New Features

- feat: add logging bucket destination for log sinks ([#226](https://github.com/googleapis/java-logging/pull/226))