### PR TITLE
fix: add default time range filter for ListLogEntries API

### DIFF
--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/ITimestampDefaultFilter.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/ITimestampDefaultFilter.java
@@ -17,15 +17,15 @@
 package com.google.cloud.logging;
 
 /**
- * Encapsulates implementation of default time filter.
- * This is needed for testing since we can't mock static classes
- * with EasyMock
+ * Encapsulates implementation of default time filter. This is needed for testing since we can't
+ * mock static classes with EasyMock
  */
 public interface ITimestampDefaultFilter {
 
-    /**
-     * Creates a default filter with timestamp to query Cloud Logging
-     * @return The filter using timestamp field
-     */
-    String createDefaultTimestampFilter();
+  /**
+   * Creates a default filter with timestamp to query Cloud Logging
+   *
+   * @return The filter using timestamp field
+   */
+  String createDefaultTimestampFilter();
 }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/ITimestampDefaultFilter.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/ITimestampDefaultFilter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging;
+
+/**
+ * Encapsulates implementation of default time filter.
+ * This is needed for testing since we can't mock static classes
+ * with EasyMock
+ */
+public interface ITimestampDefaultFilter {
+
+    /**
+     * Creates a default filter with timestamp to query Cloud Logging
+     * @return The filter using timestamp field
+     */
+    String createDefaultTimestampFilter();
+}

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -783,7 +783,9 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
     // of 24 hours back to be inline with gcloud behavior for the same API
     if (filter != null) {
       if (!filter.toLowerCase().contains("timestamp")) {
-        filter = String.format("%s AND %s", filter, defaultTimestampFilterCreator.createDefaultTimestampFilter());
+        filter =
+            String.format(
+                "%s AND %s", filter, defaultTimestampFilterCreator.createDefaultTimestampFilter());
       }
       builder.setFilter(filter);
     } else {
@@ -806,12 +808,12 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
           @Override
           public AsyncPage<LogEntry> apply(ListLogEntriesResponse listLogEntriesResponse) {
             List<LogEntry> entries =
-                    listLogEntriesResponse.getEntriesList() == null
+                listLogEntriesResponse.getEntriesList() == null
                     ? ImmutableList.<LogEntry>of()
                     : Lists.transform(
-                            listLogEntriesResponse.getEntriesList(), LogEntry.FROM_PB_FUNCTION);
+                        listLogEntriesResponse.getEntriesList(), LogEntry.FROM_PB_FUNCTION);
             String cursor =
-                    listLogEntriesResponse.getNextPageToken().equals("")
+                listLogEntriesResponse.getNextPageToken().equals("")
                     ? null
                     : listLogEntriesResponse.getNextPageToken();
             return new AsyncPageImpl<>(

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -783,7 +783,12 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
       builder.setOrderBy(orderBy);
     }
     String filter = FILTER.get(options);
+    // Make sure timestamp filter is either explicitly specified or we add a default time filter
+    // of 24 hours back to be inline with gcloud behavior for the same API
     if (filter != null) {
+      if (!filter.contains("timestamp")) {
+        filter = String.format("%s AND %s", filter, createDefaultTimeRangeFilter());
+      }
       builder.setFilter(filter);
     } else {
       // If filter is not specified, default filter is looking back 24 hours in line with gcloud
@@ -853,7 +858,8 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
     return pendingWrites.size();
   }
 
-  private static String createDefaultTimeRangeFilter() {
+  @VisibleForTesting
+  static String createDefaultTimeRangeFilter() {
     DateFormat rfcDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
     return "timestamp>=\"" + rfcDateFormat.format(yesterday()) + "\"";
   }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -784,10 +784,10 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
     }
     String filter = FILTER.get(options);
     if (filter != null) {
-        builder.setFilter(filter);
-      }
-    else {
-      // If filter is not specified, default filter is looking back 24 hours in line with gcloud behavior
+      builder.setFilter(filter);
+    } else {
+      // If filter is not specified, default filter is looking back 24 hours in line with gcloud
+      // behavior
       builder.setFilter(createDefaultTimeRangeFilter());
     }
 

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -49,7 +49,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.logging.v2.*;
 import com.google.protobuf.Empty;
-
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -706,7 +705,7 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
 
   private static String createDefaultTimeRangeFilter() {
     DateFormat rfcDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-    return  "timestamp>=\"" + rfcDateFormat.format(yesterday()) + "\"";
+    return "timestamp>=\"" + rfcDateFormat.format(yesterday()) + "\"";
   }
 
   private static Date yesterday() {

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -782,7 +782,7 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
     // Make sure timestamp filter is either explicitly specified or we add a default time filter
     // of 24 hours back to be inline with gcloud behavior for the same API
     if (filter != null) {
-      if (!filter.contains("timestamp")) {
+      if (!filter.toLowerCase().contains("timestamp")) {
         filter = String.format("%s AND %s", filter, defaultTimestampFilterCreator.createDefaultTimestampFilter());
       }
       builder.setFilter(filter);

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -36,7 +36,6 @@ import com.google.cloud.BaseService;
 import com.google.cloud.MonitoredResource;
 import com.google.cloud.MonitoredResourceDescriptor;
 import com.google.cloud.PageImpl;
-import com.google.cloud.logging.Logging.EntryListOption.OptionType;
 import com.google.cloud.logging.spi.v2.LoggingRpc;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
@@ -785,8 +784,8 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
     }
     String filter = FILTER.get(options);
     if (filter != null) {
-      builder.setFilter(filter);
-    }
+        builder.setFilter(filter);
+      }
     else {
       // If filter is not specified, default filter is looking back 24 hours in line with gcloud behavior
       builder.setFilter(createDefaultTimeRangeFilter());

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/TimestampDefaultFilter.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/TimestampDefaultFilter.java
@@ -23,18 +23,18 @@ import java.util.Date;
 import java.util.TimeZone;
 
 public class TimestampDefaultFilter implements ITimestampDefaultFilter {
-    @Override
-    public String createDefaultTimestampFilter() {
-        DateFormat rfcDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-        rfcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return "timestamp>=\"" + rfcDateFormat.format(yesterday()) + "\"";
-    }
+  @Override
+  public String createDefaultTimestampFilter() {
+    DateFormat rfcDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+    rfcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    return "timestamp>=\"" + rfcDateFormat.format(yesterday()) + "\"";
+  }
 
-    private Date yesterday() {
-        TimeZone timeZone = TimeZone.getTimeZone("UTC");
-        Calendar calendar = Calendar.getInstance(timeZone);
-        calendar.add(Calendar.DATE, -1);
+  private Date yesterday() {
+    TimeZone timeZone = TimeZone.getTimeZone("UTC");
+    Calendar calendar = Calendar.getInstance(timeZone);
+    calendar.add(Calendar.DATE, -1);
 
-        return calendar.getTime();
-    }
+    return calendar.getTime();
+  }
 }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/TimestampDefaultFilter.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/TimestampDefaultFilter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+public class TimestampDefaultFilter implements ITimestampDefaultFilter {
+    @Override
+    public String createDefaultTimestampFilter() {
+        DateFormat rfcDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        rfcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return "timestamp>=\"" + rfcDateFormat.format(yesterday()) + "\"";
+    }
+
+    private Date yesterday() {
+        TimeZone timeZone = TimeZone.getTimeZone("UTC");
+        Calendar calendar = Calendar.getInstance(timeZone);
+        calendar.add(Calendar.DATE, -1);
+
+        return calendar.getTime();
+    }
+}

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -68,6 +68,11 @@ import com.google.logging.v2.UpdateSinkRequest;
 import com.google.logging.v2.WriteLogEntriesRequest;
 import com.google.logging.v2.WriteLogEntriesResponse;
 import com.google.protobuf.Empty;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -1291,8 +1296,11 @@ public class LoggingImplTest {
     String cursor = "cursor";
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
-    ListLogEntriesRequest request =
-        ListLogEntriesRequest.newBuilder().addResourceNames(PROJECT_PB).build();
+    ListLogEntriesRequest request = ListLogEntriesRequest.newBuilder()
+       .addResourceNames(PROJECT_PB)
+       .setFilter(createDefaultTimeRangeFilter())
+       .build();
+        
     List<LogEntry> entriesList = ImmutableList.of(LOG_ENTRY1, LOG_ENTRY2);
     ListLogEntriesResponse response =
         ListLogEntriesResponse.newBuilder()
@@ -1312,12 +1320,16 @@ public class LoggingImplTest {
     String cursor1 = "cursor";
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
-    ListLogEntriesRequest request1 =
-        ListLogEntriesRequest.newBuilder().addResourceNames(PROJECT_PB).build();
+    ListLogEntriesRequest request1 = ListLogEntriesRequest
+       .newBuilder()
+       .addResourceNames(PROJECT_PB)
+       .setFilter(createDefaultTimeRangeFilter())
+       .build();
     ListLogEntriesRequest request2 =
         ListLogEntriesRequest.newBuilder()
             .addResourceNames(PROJECT_PB)
             .setPageToken(cursor1)
+            .setFilter(createDefaultTimeRangeFilter())
             .build();
     List<LogEntry> descriptorList1 = ImmutableList.of(LOG_ENTRY1, LOG_ENTRY2);
     List<LogEntry> descriptorList2 = ImmutableList.of(LOG_ENTRY1);
@@ -1353,7 +1365,10 @@ public class LoggingImplTest {
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
     ListLogEntriesRequest request =
-        ListLogEntriesRequest.newBuilder().addResourceNames(PROJECT_PB).build();
+        ListLogEntriesRequest.newBuilder()
+        .addResourceNames(PROJECT_PB)
+        .setFilter(createDefaultTimeRangeFilter()).build();
+
     List<LogEntry> entriesList = ImmutableList.of();
     ListLogEntriesResponse response =
         ListLogEntriesResponse.newBuilder()
@@ -1401,8 +1416,9 @@ public class LoggingImplTest {
     String cursor = "cursor";
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
-    ListLogEntriesRequest request =
-        ListLogEntriesRequest.newBuilder().addResourceNames(PROJECT_PB).build();
+    ListLogEntriesRequest request = ListLogEntriesRequest.newBuilder()
+        .addResourceNames(PROJECT_PB)
+        .setFilter(createDefaultTimeRangeFilter()).build();
     List<LogEntry> entriesList = ImmutableList.of(LOG_ENTRY1, LOG_ENTRY2);
     ListLogEntriesResponse response =
         ListLogEntriesResponse.newBuilder()
@@ -1422,13 +1438,17 @@ public class LoggingImplTest {
     String cursor1 = "cursor";
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
-    ListLogEntriesRequest request1 =
-        ListLogEntriesRequest.newBuilder().addResourceNames(PROJECT_PB).build();
-    ListLogEntriesRequest request2 =
-        ListLogEntriesRequest.newBuilder()
-            .addResourceNames(PROJECT_PB)
-            .setPageToken(cursor1)
-            .build();
+    ListLogEntriesRequest request1 = ListLogEntriesRequest
+       .newBuilder()
+       .addResourceNames(PROJECT_PB)
+       .setFilter(createDefaultTimeRangeFilter())
+       .build();
+    ListLogEntriesRequest request2 = ListLogEntriesRequest
+       .newBuilder()
+       .addResourceNames(PROJECT_PB)
+       .setFilter(createDefaultTimeRangeFilter())
+       .setPageToken(cursor1)
+       .build();
     List<LogEntry> descriptorList1 = ImmutableList.of(LOG_ENTRY1, LOG_ENTRY2);
     List<LogEntry> descriptorList2 = ImmutableList.of(LOG_ENTRY1);
     ListLogEntriesResponse response1 =
@@ -1458,12 +1478,14 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testListLogEntriesAyncEmpty() throws ExecutionException, InterruptedException {
+  public void testListLogEntriesAsyncEmpty() throws ExecutionException, InterruptedException {
     String cursor = "cursor";
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
     ListLogEntriesRequest request =
-        ListLogEntriesRequest.newBuilder().addResourceNames(PROJECT_PB).build();
+        ListLogEntriesRequest.newBuilder()
+            .addResourceNames(PROJECT_PB)
+            .setFilter(createDefaultTimeRangeFilter()).build();
     List<LogEntry> entriesList = ImmutableList.of();
     ListLogEntriesResponse response =
         ListLogEntriesResponse.newBuilder()
@@ -1583,5 +1605,21 @@ public class LoggingImplTest {
       threads[i].join();
     }
     assertSame(0, exceptions.get());
+  }
+
+  private static String createDefaultTimeRangeFilter() {
+    DateFormat rfcDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+    return  "timestamp>=\"" + rfcDateFormat.format(yesterday()) + "\"";
+  }
+
+  private static Date yesterday() {
+    Calendar calendar = Calendar.getInstance();
+    calendar.add(Calendar.DATE, -1);
+    calendar.set(Calendar.HOUR_OF_DAY, 0);
+    calendar.set(Calendar.MINUTE, 0);
+    calendar.set(Calendar.SECOND, 0);
+    calendar.set(Calendar.MILLISECOND, 0);
+
+    return calendar.getTime();
   }
 }

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -1825,7 +1825,8 @@ public class LoggingImplTest {
         ListLogEntriesRequest.newBuilder()
             .addResourceNames(PROJECT_PB)
             .setOrderBy("timestamp desc")
-            .setFilter("logName:syslog")
+            .setFilter(
+                String.format("logName:syslog AND %s", LoggingImpl.createDefaultTimeRangeFilter()))
             .build();
     List<LogEntry> entriesList = ImmutableList.of(LOG_ENTRY1, LOG_ENTRY2);
     ListLogEntriesResponse response =
@@ -1945,7 +1946,8 @@ public class LoggingImplTest {
         ListLogEntriesRequest.newBuilder()
             .addResourceNames(PROJECT_PB)
             .setOrderBy("timestamp desc")
-            .setFilter("logName:syslog")
+            .setFilter(
+                String.format("logName:syslog AND %s", LoggingImpl.createDefaultTimeRangeFilter()))
             .build();
     List<LogEntry> entriesList = ImmutableList.of(LOG_ENTRY1, LOG_ENTRY2);
     ListLogEntriesResponse response =

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -1441,8 +1441,8 @@ public class LoggingImplTest {
     String cursor1 = "cursor";
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
-    ListLogEntriesRequest request1 = 
-        ListLogEntriesRequest.newBuilder()
+    ListLogEntriesRequest request1 =
+    ListLogEntriesRequest request2 =
             .addResourceNames(PROJECT_PB)
             .setFilter(createDefaultTimeRangeFilter())
             .build();

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -1417,7 +1417,7 @@ public class LoggingImplTest {
     String cursor = "cursor";
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
-    ListLogEntriesRequest request = 
+    ListLogEntriesRequest request =
         ListLogEntriesRequest.newBuilder()
             .addResourceNames(PROJECT_PB)
             .setFilter(createDefaultTimeRangeFilter())

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -77,8 +77,6 @@ import com.google.logging.v2.WriteLogEntriesRequest;
 import com.google.logging.v2.WriteLogEntriesResponse;
 import com.google.protobuf.Empty;
 import com.google.protobuf.Timestamp;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -192,12 +190,13 @@ public class LoggingImplTest {
     // However when testing, the time when it was called by the test and by the method
     // implementation might differ by microseconds so we use the same time filter implementation
     // for test and in "real" method
-    LoggingImpl.defaultTimestampFilterCreator = new ITimestampDefaultFilter() {
-      @Override
-      public String createDefaultTimestampFilter() {
-        return "timestamp>=\"2020-10-30T15:39:09Z\"";
-      }
-    };
+    LoggingImpl.defaultTimestampFilterCreator =
+        new ITimestampDefaultFilter() {
+          @Override
+          public String createDefaultTimestampFilter() {
+            return "timestamp>=\"2020-10-30T15:39:09Z\"";
+          }
+        };
   }
 
   @After
@@ -1744,7 +1743,8 @@ public class LoggingImplTest {
             .addAllEntries(Lists.transform(entriesList, LogEntry.toPbFunction(PROJECT)))
             .build();
     ApiFuture<ListLogEntriesResponse> futureResponse = ApiFutures.immediateFuture(response);
-    EasyMock.expect(loggingRpcMock.list(EasyMock.anyObject(ListLogEntriesRequest.class))).andReturn(futureResponse);
+    EasyMock.expect(loggingRpcMock.list(EasyMock.anyObject(ListLogEntriesRequest.class)))
+        .andReturn(futureResponse);
     EasyMock.replay(loggingRpcMock);
     Page<LogEntry> page = logging.listLogEntries();
     assertEquals(cursor, page.getNextPageToken());
@@ -1757,7 +1757,8 @@ public class LoggingImplTest {
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
 
-    String defaultTimeFilter = LoggingImpl.defaultTimestampFilterCreator.createDefaultTimestampFilter();
+    String defaultTimeFilter =
+        LoggingImpl.defaultTimestampFilterCreator.createDefaultTimestampFilter();
     ListLogEntriesRequest request1 =
         ListLogEntriesRequest.newBuilder()
             .addResourceNames(PROJECT_PB)
@@ -1832,7 +1833,9 @@ public class LoggingImplTest {
             .addResourceNames(PROJECT_PB)
             .setOrderBy("timestamp desc")
             .setFilter(
-                String.format("logName:syslog AND %s", LoggingImpl.defaultTimestampFilterCreator.createDefaultTimestampFilter()))
+                String.format(
+                    "logName:syslog AND %s",
+                    LoggingImpl.defaultTimestampFilterCreator.createDefaultTimestampFilter()))
             .build();
     List<LogEntry> entriesList = ImmutableList.of(LOG_ENTRY1, LOG_ENTRY2);
     ListLogEntriesResponse response =
@@ -1948,7 +1951,10 @@ public class LoggingImplTest {
     String cursor = "cursor";
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
-    String filter = String.format("logName:syslog AND %s", LoggingImpl.defaultTimestampFilterCreator.createDefaultTimestampFilter());
+    String filter =
+        String.format(
+            "logName:syslog AND %s",
+            LoggingImpl.defaultTimestampFilterCreator.createDefaultTimestampFilter());
     ListLogEntriesRequest request =
         ListLogEntriesRequest.newBuilder()
             .addResourceNames(PROJECT_PB)

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -76,11 +76,11 @@ import com.google.logging.v2.UpdateSinkRequest;
 import com.google.logging.v2.WriteLogEntriesRequest;
 import com.google.logging.v2.WriteLogEntriesResponse;
 import com.google.protobuf.Empty;
+import com.google.protobuf.Timestamp;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
-import com.google.protobuf.Timestamp;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -1727,12 +1727,12 @@ public class LoggingImplTest {
     String cursor = "cursor";
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
-    ListLogEntriesRequest request = 
+    ListLogEntriesRequest request =
         ListLogEntriesRequest.newBuilder()
-           .addResourceNames(PROJECT_PB)
-           .setFilter(createDefaultTimeRangeFilter())
-           .build();
-        
+            .addResourceNames(PROJECT_PB)
+            .setFilter(createDefaultTimeRangeFilter())
+            .build();
+
     List<LogEntry> entriesList = ImmutableList.of(LOG_ENTRY1, LOG_ENTRY2);
     ListLogEntriesResponse response =
         ListLogEntriesResponse.newBuilder()
@@ -1752,12 +1752,12 @@ public class LoggingImplTest {
     String cursor1 = "cursor";
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
-    ListLogEntriesRequest request1 = 
+    ListLogEntriesRequest request1 =
         ListLogEntriesRequest.newBuilder()
             .addResourceNames(PROJECT_PB)
             .setFilter(createDefaultTimeRangeFilter())
             .build();
-    ListLogEntriesRequest request2 = 
+    ListLogEntriesRequest request2 =
         ListLogEntriesRequest.newBuilder()
             .addResourceNames(PROJECT_PB)
             .setPageToken(cursor1)
@@ -1874,11 +1874,11 @@ public class LoggingImplTest {
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
     ListLogEntriesRequest request1 =
-    ListLogEntriesRequest request2 =
+        ListLogEntriesRequest.newBuilder()
             .addResourceNames(PROJECT_PB)
             .setFilter(createDefaultTimeRangeFilter())
             .build();
-    ListLogEntriesRequest request2 = 
+    ListLogEntriesRequest request2 =
         ListLogEntriesRequest.newBuilder()
             .addResourceNames(PROJECT_PB)
             .setFilter(createDefaultTimeRangeFilter())
@@ -1920,7 +1920,8 @@ public class LoggingImplTest {
     ListLogEntriesRequest request =
         ListLogEntriesRequest.newBuilder()
             .addResourceNames(PROJECT_PB)
-            .setFilter(createDefaultTimeRangeFilter()).build();
+            .setFilter(createDefaultTimeRangeFilter())
+            .build();
     List<LogEntry> entriesList = ImmutableList.of();
     ListLogEntriesResponse response =
         ListLogEntriesResponse.newBuilder()

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -68,7 +68,6 @@ import com.google.logging.v2.UpdateSinkRequest;
 import com.google.logging.v2.WriteLogEntriesRequest;
 import com.google.logging.v2.WriteLogEntriesResponse;
 import com.google.protobuf.Empty;
-
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -1296,10 +1295,11 @@ public class LoggingImplTest {
     String cursor = "cursor";
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
-    ListLogEntriesRequest request = ListLogEntriesRequest.newBuilder()
-       .addResourceNames(PROJECT_PB)
-       .setFilter(createDefaultTimeRangeFilter())
-       .build();
+    ListLogEntriesRequest request = 
+        ListLogEntriesRequest.newBuilder()
+           .addResourceNames(PROJECT_PB)
+           .setFilter(createDefaultTimeRangeFilter())
+           .build();
         
     List<LogEntry> entriesList = ImmutableList.of(LOG_ENTRY1, LOG_ENTRY2);
     ListLogEntriesResponse response =
@@ -1320,12 +1320,12 @@ public class LoggingImplTest {
     String cursor1 = "cursor";
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
-    ListLogEntriesRequest request1 = ListLogEntriesRequest
-       .newBuilder()
-       .addResourceNames(PROJECT_PB)
-       .setFilter(createDefaultTimeRangeFilter())
-       .build();
-    ListLogEntriesRequest request2 =
+    ListLogEntriesRequest request1 = 
+        ListLogEntriesRequest.newBuilder()
+            .addResourceNames(PROJECT_PB)
+            .setFilter(createDefaultTimeRangeFilter())
+            .build();
+    ListLogEntriesRequest request2 = 
         ListLogEntriesRequest.newBuilder()
             .addResourceNames(PROJECT_PB)
             .setPageToken(cursor1)
@@ -1366,8 +1366,9 @@ public class LoggingImplTest {
     logging = options.getService();
     ListLogEntriesRequest request =
         ListLogEntriesRequest.newBuilder()
-        .addResourceNames(PROJECT_PB)
-        .setFilter(createDefaultTimeRangeFilter()).build();
+            .addResourceNames(PROJECT_PB)
+            .setFilter(createDefaultTimeRangeFilter())
+            .build();
 
     List<LogEntry> entriesList = ImmutableList.of();
     ListLogEntriesResponse response =
@@ -1416,9 +1417,11 @@ public class LoggingImplTest {
     String cursor = "cursor";
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
-    ListLogEntriesRequest request = ListLogEntriesRequest.newBuilder()
-        .addResourceNames(PROJECT_PB)
-        .setFilter(createDefaultTimeRangeFilter()).build();
+    ListLogEntriesRequest request = 
+        ListLogEntriesRequest.newBuilder()
+            .addResourceNames(PROJECT_PB)
+            .setFilter(createDefaultTimeRangeFilter())
+            .build();
     List<LogEntry> entriesList = ImmutableList.of(LOG_ENTRY1, LOG_ENTRY2);
     ListLogEntriesResponse response =
         ListLogEntriesResponse.newBuilder()
@@ -1438,17 +1441,17 @@ public class LoggingImplTest {
     String cursor1 = "cursor";
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
-    ListLogEntriesRequest request1 = ListLogEntriesRequest
-       .newBuilder()
-       .addResourceNames(PROJECT_PB)
-       .setFilter(createDefaultTimeRangeFilter())
-       .build();
-    ListLogEntriesRequest request2 = ListLogEntriesRequest
-       .newBuilder()
-       .addResourceNames(PROJECT_PB)
-       .setFilter(createDefaultTimeRangeFilter())
-       .setPageToken(cursor1)
-       .build();
+    ListLogEntriesRequest request1 = 
+        ListLogEntriesRequest.newBuilder()
+            .addResourceNames(PROJECT_PB)
+            .setFilter(createDefaultTimeRangeFilter())
+            .build();
+    ListLogEntriesRequest request2 = 
+        ListLogEntriesRequest.newBuilder()
+            .addResourceNames(PROJECT_PB)
+            .setFilter(createDefaultTimeRangeFilter())
+            .setPageToken(cursor1)
+            .build();
     List<LogEntry> descriptorList1 = ImmutableList.of(LOG_ENTRY1, LOG_ENTRY2);
     List<LogEntry> descriptorList2 = ImmutableList.of(LOG_ENTRY1);
     ListLogEntriesResponse response1 =
@@ -1609,7 +1612,7 @@ public class LoggingImplTest {
 
   private static String createDefaultTimeRangeFilter() {
     DateFormat rfcDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-    return  "timestamp>=\"" + rfcDateFormat.format(yesterday()) + "\"";
+    return "timestamp>=\"" + rfcDateFormat.format(yesterday()) + "\"";
   }
 
   private static Date yesterday() {

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/TimestampDefaultFilterTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/TimestampDefaultFilterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging;
+
+import org.junit.Test;
+
+import javax.management.timer.Timer;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class TimestampDefaultFilterTest {
+
+    @Test
+    public void DefaultTimestampFilterTest() {
+        ITimestampDefaultFilter filter = new TimestampDefaultFilter();
+
+        TimeZone timeZone = TimeZone.getTimeZone("UTC");
+        Calendar calendar = Calendar.getInstance(timeZone);
+        calendar.add(Calendar.DATE, -1);
+        Date expected = calendar.getTime();
+
+        // Timestamp filter exists
+        String defaultFilter = filter.createDefaultTimestampFilter();
+        assertTrue(defaultFilter.contains("timestamp>="));
+
+        // Time is last 24 hours
+        try {
+            DateFormat rfcDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+            rfcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date actual = rfcDateFormat.parse(defaultFilter.substring(12, defaultFilter.length() - 1));
+            assertTrue(Math.abs(expected.getTime() - actual.getTime()) < Timer.ONE_MINUTE);
+        }
+        catch (java.text.ParseException ex) {
+            fail(); // Just fail if exception is thrown
+        }
+    }
+}

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/TimestampDefaultFilterTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/TimestampDefaultFilterTest.java
@@ -16,42 +16,40 @@
 
 package com.google.cloud.logging;
 
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import javax.management.timer.Timer;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import javax.management.timer.Timer;
+import org.junit.Test;
 
 public class TimestampDefaultFilterTest {
 
-    @Test
-    public void DefaultTimestampFilterTest() {
-        ITimestampDefaultFilter filter = new TimestampDefaultFilter();
+  @Test
+  public void DefaultTimestampFilterTest() {
+    ITimestampDefaultFilter filter = new TimestampDefaultFilter();
 
-        TimeZone timeZone = TimeZone.getTimeZone("UTC");
-        Calendar calendar = Calendar.getInstance(timeZone);
-        calendar.add(Calendar.DATE, -1);
-        Date expected = calendar.getTime();
+    TimeZone timeZone = TimeZone.getTimeZone("UTC");
+    Calendar calendar = Calendar.getInstance(timeZone);
+    calendar.add(Calendar.DATE, -1);
+    Date expected = calendar.getTime();
 
-        // Timestamp filter exists
-        String defaultFilter = filter.createDefaultTimestampFilter();
-        assertTrue(defaultFilter.contains("timestamp>="));
+    // Timestamp filter exists
+    String defaultFilter = filter.createDefaultTimestampFilter();
+    assertTrue(defaultFilter.contains("timestamp>="));
 
-        // Time is last 24 hours
-        try {
-            DateFormat rfcDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-            rfcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-            Date actual = rfcDateFormat.parse(defaultFilter.substring(12, defaultFilter.length() - 1));
-            assertTrue(Math.abs(expected.getTime() - actual.getTime()) < Timer.ONE_MINUTE);
-        }
-        catch (java.text.ParseException ex) {
-            fail(); // Just fail if exception is thrown
-        }
+    // Time is last 24 hours
+    try {
+      DateFormat rfcDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+      rfcDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+      Date actual = rfcDateFormat.parse(defaultFilter.substring(12, defaultFilter.length() - 1));
+      assertTrue(Math.abs(expected.getTime() - actual.getTime()) < Timer.ONE_MINUTE);
+    } catch (java.text.ParseException ex) {
+      fail(); // Just fail if exception is thrown
     }
+  }
 }


### PR DESCRIPTION
Making the behavior of ListLogEntries API consistent with gcloud: if filter wasn't specified we now attach a default filter of last 24 hours. This will prevent calls from hanging when listing all logs from projects with high log volumes.

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-logging/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #303 ☕️
