### PR TITLE
chore: add back blunderbuss configs overridden by yoshi-automation

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,7 +1,11 @@
 # Configuration for the Blunderbuss GitHub app. For more info see
 # https://github.com/googleapis/repo-automation-bots/tree/master/packages/blunderbuss
+assign_issues:
+  - simonz130
+assign_prs:
+  - simonz130
 assign_prs_by:
-- labels:
-  - samples
-  to:
-  - googleapis/java-samples-reviewers
+  - labels:
+    - samples
+    to:
+    - googleapis/java-samples-reviewers


### PR DESCRIPTION
Adds back blunderbuss configs overridden by yoshi-automation