### PR TITLE
tests: fix flaky test

### DIFF
--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITLoggingTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITLoggingTest.java
@@ -74,6 +74,7 @@ public class ITLoggingTest extends BaseSystemTest {
             .setResource(CLOUDSQL_RESOURCE)
             .build();
     logging.write(ImmutableList.of(firstEntry));
+    logging.flush();
     logging.write(ImmutableList.of(secondEntry));
     logging.flush();
   }


### PR DESCRIPTION
ITLoggingTest recently became flaky. It looks like it's sometimes retrieving logs in a different order than they were sent. 

I fixed this by adding a second flush statement to the test code, but I also opened https://github.com/googleapis/java-logging/issues/426 to discuss whether this is a test bug or a behaviour bug