### PR TITLE
test: add env-tests-logging submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "env-tests-logging"]
+	path = env-tests-logging
+	url = https://github.com/googleapis/env-tests-logging


### PR DESCRIPTION
Adding environment tests repo as a submodule.

This PR is part of onboarding to environment tests framework for java-logging repo.
