### PR TITLE
fix: add space to fix embedding exclusion in docs

### DIFF
--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -41,6 +41,7 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-logging</artifactId>
     </dependency>
+    
     <!-- [START_EXCLUDE] -->
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
When the bom instructions feature at https://cloud.google.com/logging/docs/reference/libraries?hl=en
there is a weird part there:
```xml
<!-- ...
</dependencies>
```

Comparing to other libraries in java, it looks like we need to add a line break.
