### PR TITLE
chore(doc): remove duplicated region tag for logging_list_log_entries

### DIFF
--- a/google-cloud-logging/clirr-ignored-differences.xml
+++ b/google-cloud-logging/clirr-ignored-differences.xml
@@ -6,12 +6,12 @@
     <difference>
         <differenceType>7012</differenceType>
         <className>com/google/cloud/logging/Logging</className>
-        <method>*</method>
+        <method>* listLogs*(com.google.cloud.logging.Logging$ListOption[])</method>
     </difference>
     <!-- Added methods to com.google.cloud.logging.spi.v2.LoggingRpc interface with implementation in GrpcLoggingRpc is always okay -->
     <difference>
         <differenceType>7012</differenceType>
         <className>com/google/cloud/logging/spi/v2/LoggingRpc</className>
-        <method>*</method>
+        <method>* list(com.google.logging.v2.ListLogsRequest)</method>
     </difference>
 </differences>

--- a/google-cloud-logging/clirr-ignored-differences.xml
+++ b/google-cloud-logging/clirr-ignored-differences.xml
@@ -12,6 +12,6 @@
     <difference>
         <differenceType>7012</differenceType>
         <className>com/google/cloud/logging/spi/v2/LoggingRpc</className>
-        <method>* list(com.google.logging.v2.ListLogsRequest)</method>
+        <method>* listLogs(com.google.logging.v2.ListLogsRequest)</method>
     </difference>
 </differences>

--- a/google-cloud-logging/clirr-ignored-differences.xml
+++ b/google-cloud-logging/clirr-ignored-differences.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<!-- added to resolve breaking changes until JDK will be upgraded to ≥1.8 -->
+<differences>
+    <!-- Added methods to com.google.cloud.logging.Logging interface with implementation in LoggingImpl is always okay -->
+    <difference>
+        <differenceType>7012</differenceType>
+        <className>com/google/cloud/logging/Logging</className>
+        <method>*</method>
+    </difference>
+    <!-- Added methods to com.google.cloud.logging.spi.v2.LoggingRpc interface with implementation in GrpcLoggingRpc is always okay -->
+    <difference>
+        <differenceType>7012</differenceType>
+        <className>com/google/cloud/logging/spi/v2/LoggingRpc</className>
+        <method>*</method>
+    </difference>
+</differences>

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
@@ -415,6 +415,47 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
   ApiFuture<Boolean> deleteSinkAsync(String sink);
 
   /**
+   * Lists the log names. This method returns a {@link Page} object that can be used to consume
+   * paginated results. Use {@link ListOption} to specify the page size or the page token from which
+   * to start listing logs.
+   *
+   * <p>Example of listing log names, specifying the page size.
+   *
+   * <pre>{@code
+   * Page<Log> logNames = logging.listLogs(ListOption.pageSize(100));
+   * Iterator<Log> logIterator = logNames.iterateAll().iterator();
+   * while (logIterator.hasNext()) {
+   *   String logName = logIterator.next();
+   *   // do something with the log name
+   * }
+   * }</pre>
+   *
+   * @throws LoggingException upon failure
+   */
+  Page<String> listLogs(ListOption... options);
+
+  /**
+   * Sends a request for listing log names. This method returns a {@code ApiFuture} object to
+   * consume the result. {@link ApiFuture#get()} returns an {@link AsyncPage} object that can be
+   * used to asynchronously handle paginated results. Use {@link ListOption} to specify the page
+   * size or the page token from which to start listing log names.
+   *
+   * <p>Example of asynchronously listing log names, specifying the page size.
+   *
+   * <pre>{@code
+   * ApiFuture<AsyncPage<Log>> future = logging.listLogsAsync(ListOption.pageSize(100));
+   * // ...
+   * AsyncPage<Sink> logNames = future.get();
+   * Iterator<Sink> logIterator = logNames.iterateAll().iterator();
+   * while (logIterator.hasNext()) {
+   *   String logName = logIterator.next();
+   *   // do something with the log name
+   * }
+   * }</pre>
+   */
+  ApiFuture<AsyncPage<String>> listLogsAsync(ListOption... options);
+
+  /**
    * Deletes a log and all its log entries. The log will reappear if new entries are written to it.
    *
    * <p>Example of deleting a log.

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
@@ -432,7 +432,10 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
    *
    * @throws LoggingException upon failure
    */
-  Page<String> listLogs(ListOption... options);
+  default Page<String> listLogs(ListOption... options) {
+    throw new UnsupportedOperationException(
+        "method listLogs() does not have default implementation");
+  }
 
   /**
    * Sends a request for listing log names. This method returns a {@code ApiFuture} object to
@@ -453,7 +456,10 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
    * }
    * }</pre>
    */
-  ApiFuture<AsyncPage<String>> listLogsAsync(ListOption... options);
+  default ApiFuture<AsyncPage<String>> listLogsAsync(ListOption... options) {
+    throw new UnsupportedOperationException(
+        "method listLogsAsync() does not have default implementation");
+  }
 
   /**
    * Deletes a log and all its log entries. The log will reappear if new entries are written to it.

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -199,8 +199,6 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
 
   private static class LogNamePageFetcher extends BasePageFetcher<String> {
 
-    private static final long serialVersionUID = 7156613795615829594L;
-
     LogNamePageFetcher(
         LoggingOptions serviceOptions, String cursor, Map<Option.OptionType, ?> requestOptions) {
       super(serviceOptions, cursor, requestOptions);

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -384,9 +384,8 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
   /**
    * Creates a new {@code ListLogsRequest} object.
    *
-   * Builds an instance of {@code ListLogsRequest} using page size, page token and project id
-   * from the {@code LoggingOptions}.
-   * The project id is used as the request's parent parameter.
+   * <p>Builds an instance of {@code ListLogsRequest} using page size, page token and project id
+   * from the {@code LoggingOptions}. The project id is used as the request's parent parameter.
    *
    * @see com.google.logging.v2.ListLogEntriesRequest
    * @return the created {@code ListLogsRequest} object

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -65,6 +65,8 @@ import com.google.logging.v2.ListLogEntriesRequest;
 import com.google.logging.v2.ListLogEntriesResponse;
 import com.google.logging.v2.ListLogMetricsRequest;
 import com.google.logging.v2.ListLogMetricsResponse;
+import com.google.logging.v2.ListLogsRequest;
+import com.google.logging.v2.ListLogsResponse;
 import com.google.logging.v2.ListMonitoredResourceDescriptorsRequest;
 import com.google.logging.v2.ListMonitoredResourceDescriptorsResponse;
 import com.google.logging.v2.ListSinksRequest;
@@ -192,6 +194,21 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
     @Override
     public ApiFuture<AsyncPage<Sink>> getNextPage() {
       return listSinksAsync(serviceOptions(), requestOptions());
+    }
+  }
+
+  private static class LogNamePageFetcher extends BasePageFetcher<String> {
+
+    private static final long serialVersionUID = 5L;
+
+    LogNamePageFetcher(
+        LoggingOptions serviceOptions, String cursor, Map<Option.OptionType, ?> requestOptions) {
+      super(serviceOptions, cursor, requestOptions);
+    }
+
+    @Override
+    public ApiFuture<AsyncPage<String>> getNextPage() {
+      return listLogsAsync(serviceOptions(), requestOptions());
     }
   }
 
@@ -364,6 +381,54 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
                 LogSinkName.ofProjectSinkName(getOptions().getProjectId(), sink).toString())
             .build();
     return transform(rpc.delete(request), EMPTY_TO_BOOLEAN_FUNCTION);
+  }
+
+  private static ListLogsRequest listLogsRequest(
+      LoggingOptions serviceOptions, Map<Option.OptionType, ?> options) {
+    ListLogsRequest.Builder builder = ListLogsRequest.newBuilder();
+    builder.setParent(ProjectName.of(serviceOptions.getProjectId()).toString());
+    Integer pageSize = PAGE_SIZE.get(options);
+    String pageToken = PAGE_TOKEN.get(options);
+    if (pageSize != null) {
+      builder.setPageSize(pageSize);
+    }
+    if (pageToken != null) {
+      builder.setPageToken(pageToken);
+    }
+    return builder.build();
+  }
+
+  private static ApiFuture<AsyncPage<String>> listLogsAsync(
+      final LoggingOptions serviceOptions, final Map<Option.OptionType, ?> options) {
+    final ListLogsRequest request = listLogsRequest(serviceOptions, options);
+    ApiFuture<ListLogsResponse> list = serviceOptions.getLoggingRpcV2().list(request);
+    return transform(
+        list,
+        new Function<ListLogsResponse, AsyncPage<String>>() {
+          @Override
+          public AsyncPage<String> apply(ListLogsResponse listLogsResponse) {
+            List<String> logNames =
+                listLogsResponse.getLogNamesList() == null
+                    ? ImmutableList.<String>of()
+                    : listLogsResponse.getLogNamesList();
+            String cursor =
+                listLogsResponse.getNextPageToken().equals("")
+                    ? null
+                    : listLogsResponse.getNextPageToken();
+            return new AsyncPageImpl<>(
+                new LogNamePageFetcher(serviceOptions, cursor, options), cursor, logNames);
+          }
+        });
+  }
+
+  @Override
+  public Page<String> listLogs(ListOption... options) {
+    return get(listLogsAsync(options));
+  }
+
+  @Override
+  public ApiFuture<AsyncPage<String>> listLogsAsync(ListOption... options) {
+    return listLogsAsync(getOptions(), optionMap(options));
   }
 
   public boolean deleteLog(String log) {

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -199,7 +199,7 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
 
   private static class LogNamePageFetcher extends BasePageFetcher<String> {
 
-    private static final long serialVersionUID = 5L;
+    private static final long serialVersionUID = 7156613795615829594L;
 
     LogNamePageFetcher(
         LoggingOptions serviceOptions, String cursor, Map<Option.OptionType, ?> requestOptions) {

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -381,6 +381,16 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
     return transform(rpc.delete(request), EMPTY_TO_BOOLEAN_FUNCTION);
   }
 
+  /**
+   * Creates a new {@code ListLogsRequest} object.
+   *
+   * Builds an instance of {@code ListLogsRequest} using page size, page token and project id
+   * from the {@code LoggingOptions}.
+   * The project id is used as the request's parent parameter.
+   *
+   * @see com.google.logging.v2.ListLogEntriesRequest
+   * @return the created {@code ListLogsRequest} object
+   */
   private static ListLogsRequest listLogsRequest(
       LoggingOptions serviceOptions, Map<Option.OptionType, ?> options) {
     ListLogsRequest.Builder builder = ListLogsRequest.newBuilder();
@@ -399,7 +409,7 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
   private static ApiFuture<AsyncPage<String>> listLogsAsync(
       final LoggingOptions serviceOptions, final Map<Option.OptionType, ?> options) {
     final ListLogsRequest request = listLogsRequest(serviceOptions, options);
-    ApiFuture<ListLogsResponse> list = serviceOptions.getLoggingRpcV2().list(request);
+    ApiFuture<ListLogsResponse> list = serviceOptions.getLoggingRpcV2().listLogs(request);
     return transform(
         list,
         new Function<ListLogsResponse, AsyncPage<String>>() {

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/GrpcLoggingRpc.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/GrpcLoggingRpc.java
@@ -263,7 +263,7 @@ public class GrpcLoggingRpc implements LoggingRpc {
   }
 
   @Override
-  public ApiFuture<ListLogsResponse> list(ListLogsRequest request) {
+  public ApiFuture<ListLogsResponse> listLogs(ListLogsRequest request) {
     return translate(loggingClient.listLogsCallable().futureCall(request), true);
   }
 

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/GrpcLoggingRpc.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/GrpcLoggingRpc.java
@@ -61,6 +61,8 @@ import com.google.logging.v2.ListLogEntriesRequest;
 import com.google.logging.v2.ListLogEntriesResponse;
 import com.google.logging.v2.ListLogMetricsRequest;
 import com.google.logging.v2.ListLogMetricsResponse;
+import com.google.logging.v2.ListLogsRequest;
+import com.google.logging.v2.ListLogsResponse;
 import com.google.logging.v2.ListMonitoredResourceDescriptorsRequest;
 import com.google.logging.v2.ListMonitoredResourceDescriptorsResponse;
 import com.google.logging.v2.ListSinksRequest;
@@ -258,6 +260,11 @@ public class GrpcLoggingRpc implements LoggingRpc {
         configClient.deleteExclusionCallable().futureCall(request),
         true,
         StatusCode.Code.NOT_FOUND);
+  }
+
+  @Override
+  public ApiFuture<ListLogsResponse> list(ListLogsRequest request) {
+    return translate(loggingClient.listLogsCallable().futureCall(request), true);
   }
 
   @Override

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/LoggingRpc.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/LoggingRpc.java
@@ -34,6 +34,8 @@ import com.google.logging.v2.ListLogEntriesRequest;
 import com.google.logging.v2.ListLogEntriesResponse;
 import com.google.logging.v2.ListLogMetricsRequest;
 import com.google.logging.v2.ListLogMetricsResponse;
+import com.google.logging.v2.ListLogsRequest;
+import com.google.logging.v2.ListLogsResponse;
 import com.google.logging.v2.ListMonitoredResourceDescriptorsRequest;
 import com.google.logging.v2.ListMonitoredResourceDescriptorsResponse;
 import com.google.logging.v2.ListSinksRequest;
@@ -92,6 +94,15 @@ public interface LoggingRpc extends AutoCloseable, ServiceRpc {
    * @param request the request object containing all of the parameters for the API call
    */
   ApiFuture<Empty> delete(DeleteSinkRequest request);
+
+  /**
+   * Sends a request to list the log names in a project. This method returns a {@code ApiFuture}
+   * object to consume the result. {@link ApiFuture#get()} returns a response object containing the
+   * listing result.
+   *
+   * @param request the request object containing all of the parameters for the API call
+   */
+  ApiFuture<ListLogsResponse> list(ListLogsRequest request);
 
   /**
    * Sends a request to deletes a log. This method returns a {@code ApiFuture} object to consume the

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/LoggingRpc.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/LoggingRpc.java
@@ -102,7 +102,7 @@ public interface LoggingRpc extends AutoCloseable, ServiceRpc {
    *
    * @param request the request object containing all of the parameters for the API call
    */
-  default ApiFuture<ListLogsResponse> list(ListLogsRequest request) {
+  default ApiFuture<ListLogsResponse> listLogs(ListLogsRequest request) {
     throw new UnsupportedOperationException(
         "method list(ListLogsRequest request) does not have default implementation");
   }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/LoggingRpc.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/LoggingRpc.java
@@ -102,7 +102,10 @@ public interface LoggingRpc extends AutoCloseable, ServiceRpc {
    *
    * @param request the request object containing all of the parameters for the API call
    */
-  ApiFuture<ListLogsResponse> list(ListLogsRequest request);
+  default ApiFuture<ListLogsResponse> list(ListLogsRequest request) {
+    throw new UnsupportedOperationException(
+        "method list(ListLogsRequest request) does not have default implementation");
+  }
 
   /**
    * Sends a request to deletes a log. This method returns a {@code ApiFuture} object to consume the

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -63,6 +63,8 @@ import com.google.logging.v2.ListLogEntriesRequest;
 import com.google.logging.v2.ListLogEntriesResponse;
 import com.google.logging.v2.ListLogMetricsRequest;
 import com.google.logging.v2.ListLogMetricsResponse;
+import com.google.logging.v2.ListLogsRequest;
+import com.google.logging.v2.ListLogsResponse;
 import com.google.logging.v2.ListMonitoredResourceDescriptorsRequest;
 import com.google.logging.v2.ListMonitoredResourceDescriptorsResponse;
 import com.google.logging.v2.ListSinksRequest;
@@ -106,6 +108,9 @@ public class LoggingImplTest {
       com.google.api.MonitoredResourceDescriptor.getDefaultInstance();
   private static final MonitoredResourceDescriptor DESCRIPTOR =
       MonitoredResourceDescriptor.fromPb(DESCRIPTOR_PB);
+  private static final String LOG_NAME1 = "test-list-log-name-1";
+  private static final String LOG_NAME2 = "test-list-log-name-2";
+  private static final String LOG_NAMES_CURSOR = "cursor";
   private static final String LOG_NAME = "log";
   private static final String LOG_NAME_PB = "projects/" + PROJECT + "/logs/" + LOG_NAME;
   private static final MonitoredResource MONITORED_RESOURCE =
@@ -173,6 +178,40 @@ public class LoggingImplTest {
   private LoggingRpc loggingRpcMock;
   private Logging logging;
 
+  private void configureListLogsTests(List<String> returnedList, String cursor) {
+    ListLogsRequest request = ListLogsRequest.newBuilder().setParent(PROJECT_PB).build();
+    ListLogsResponse response =
+        ListLogsResponse.newBuilder().setNextPageToken(cursor).addAllLogNames(returnedList).build();
+    ApiFuture<ListLogsResponse> futureResponse = ApiFutures.immediateFuture(response);
+    EasyMock.expect(loggingRpcMock.list(request)).andReturn(futureResponse);
+    EasyMock.replay(loggingRpcMock);
+  }
+
+  private void configureListLogsTests(
+      List<String> page1ReturnedList,
+      List<String> page2ReturnedList,
+      String page1Cursor,
+      String page2Cursor) {
+    ListLogsRequest request1 = ListLogsRequest.newBuilder().setParent(PROJECT_PB).build();
+    ListLogsRequest request2 =
+        ListLogsRequest.newBuilder().setParent(PROJECT_PB).setPageToken(page1Cursor).build();
+    ListLogsResponse response1 =
+        ListLogsResponse.newBuilder()
+            .setNextPageToken(page1Cursor)
+            .addAllLogNames(page1ReturnedList)
+            .build();
+    ListLogsResponse response2 =
+        ListLogsResponse.newBuilder()
+            .setNextPageToken(page2Cursor)
+            .addAllLogNames(page2ReturnedList)
+            .build();
+    ApiFuture<ListLogsResponse> futureResponse1 = ApiFutures.immediateFuture(response1);
+    ApiFuture<ListLogsResponse> futureResponse2 = ApiFutures.immediateFuture(response2);
+    EasyMock.expect(loggingRpcMock.list(request1)).andReturn(futureResponse1);
+    EasyMock.expect(loggingRpcMock.list(request2)).andReturn(futureResponse2);
+    EasyMock.replay(loggingRpcMock);
+  }
+
   @Before
   public void setUp() {
     rpcFactoryMock = EasyMock.createStrictMock(LoggingRpcFactory.class);
@@ -187,8 +226,10 @@ public class LoggingImplTest {
             .build();
 
     // By default when calling ListLogEntries, we append a filter of last 24 hours.
-    // However when testing, the time when it was called by the test and by the method
-    // implementation might differ by microseconds so we use the same time filter implementation
+    // However when testing, the time when it was called by the test and by the
+    // method
+    // implementation might differ by microseconds so we use the same time filter
+    // implementation
     // for test and in "real" method
     LoggingImpl.defaultTimestampFilterCreator =
         new ITimestampDefaultFilter() {
@@ -1577,6 +1618,88 @@ public class LoggingImplTest {
   }
 
   @Test
+  public void testListLogs() {
+    EasyMock.replay(rpcFactoryMock);
+    logging = options.getService();
+    List<String> logNames = ImmutableList.of(LOG_NAME1, LOG_NAME2);
+    configureListLogsTests(logNames, LOG_NAMES_CURSOR);
+
+    Page<String> page = logging.listLogs();
+    assertEquals(LOG_NAMES_CURSOR, page.getNextPageToken());
+    assertArrayEquals(logNames.toArray(), Iterables.toArray(page.getValues(), String.class));
+  }
+
+  @Test
+  public void testListLogsEmpty() {
+    EasyMock.replay(rpcFactoryMock);
+    logging = options.getService();
+    List<String> emptyList = ImmutableList.of();
+    configureListLogsTests(emptyList, LOG_NAMES_CURSOR);
+
+    Page<String> page = logging.listLogs();
+    assertEquals(LOG_NAMES_CURSOR, page.getNextPageToken());
+    assertArrayEquals(emptyList.toArray(), Iterables.toArray(page.getValues(), String.class));
+  }
+
+  @Test
+  public void testListLogsNextPage() throws ExecutionException, InterruptedException {
+    EasyMock.replay(rpcFactoryMock);
+    logging = options.getService();
+    List<String> logNames1 = ImmutableList.of(LOG_NAME1, LOG_NAME2);
+    List<String> logNames2 = ImmutableList.of(LOG_NAME1);
+    String nextPageCursor = "nextCursor";
+    configureListLogsTests(logNames1, logNames2, LOG_NAMES_CURSOR, nextPageCursor);
+
+    Page<String> page = logging.listLogs();
+    assertEquals(LOG_NAMES_CURSOR, page.getNextPageToken());
+    assertArrayEquals(logNames1.toArray(), Iterables.toArray(page.getValues(), String.class));
+    page = page.getNextPage();
+    assertEquals(nextPageCursor, page.getNextPageToken());
+    assertArrayEquals(logNames2.toArray(), Iterables.toArray(page.getValues(), String.class));
+  }
+
+  @Test
+  public void testListLogsAsync() throws ExecutionException, InterruptedException {
+    EasyMock.replay(rpcFactoryMock);
+    logging = options.getService();
+    List<String> logNames = ImmutableList.of(LOG_NAME1, LOG_NAME2);
+    configureListLogsTests(logNames, LOG_NAMES_CURSOR);
+
+    AsyncPage<String> page = logging.listLogsAsync().get();
+    assertEquals(LOG_NAMES_CURSOR, page.getNextPageToken());
+    assertArrayEquals(logNames.toArray(), Iterables.toArray(page.getValues(), String.class));
+  }
+
+  @Test
+  public void testListLogsAsyncEmpty() throws ExecutionException, InterruptedException {
+    EasyMock.replay(rpcFactoryMock);
+    logging = options.getService();
+    List<String> emptyList = ImmutableList.of();
+    configureListLogsTests(emptyList, LOG_NAMES_CURSOR);
+
+    AsyncPage<String> page = logging.listLogsAsync().get();
+    assertEquals(LOG_NAMES_CURSOR, page.getNextPageToken());
+    assertArrayEquals(emptyList.toArray(), Iterables.toArray(page.getValues(), String.class));
+  }
+
+  @Test
+  public void testListLogsAsyncNextPage() throws ExecutionException, InterruptedException {
+    EasyMock.replay(rpcFactoryMock);
+    logging = options.getService();
+    List<String> logNames1 = ImmutableList.of(LOG_NAME1, LOG_NAME2);
+    List<String> logNames2 = ImmutableList.of(LOG_NAME1);
+    String nextPageCursor = "nextCursor";
+    configureListLogsTests(logNames1, logNames2, LOG_NAMES_CURSOR, nextPageCursor);
+
+    AsyncPage<String> page = logging.listLogsAsync().get();
+    assertEquals(LOG_NAMES_CURSOR, page.getNextPageToken());
+    assertArrayEquals(logNames1.toArray(), Iterables.toArray(page.getValues(), String.class));
+    page = page.getNextPageAsync().get();
+    assertEquals(nextPageCursor, page.getNextPageToken());
+    assertArrayEquals(logNames2.toArray(), Iterables.toArray(page.getValues(), String.class));
+  }
+
+  @Test
   public void testDeleteLog() {
     DeleteLogRequest request = DeleteLogRequest.newBuilder().setLogName(LOG_NAME_PB).build();
     ApiFuture<Empty> response = ApiFutures.immediateFuture(Empty.getDefaultInstance());
@@ -2034,7 +2157,8 @@ public class LoggingImplTest {
     EasyMock.expect(loggingRpcMock.write(request)).andReturn(mockRpcResponse).times(threads.length);
     EasyMock.replay(loggingRpcMock);
 
-    // log and flush concurrently in many threads to trigger a ConcurrentModificationException
+    // log and flush concurrently in many threads to trigger a
+    // ConcurrentModificationException
     final AtomicInteger exceptions = new AtomicInteger(0);
     for (int i = 0; i < threads.length; i++) {
       threads[i] =

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -1683,7 +1683,8 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testListLogsAsyncNextPageWithLogNames() throws ExecutionException, InterruptedException {
+  public void testListLogsAsyncNextPageWithLogNames()
+      throws ExecutionException, InterruptedException {
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
     List<String> logNames1 = ImmutableList.of(LOG_NAME1, LOG_NAME2);

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -183,7 +183,7 @@ public class LoggingImplTest {
     ListLogsResponse response =
         ListLogsResponse.newBuilder().setNextPageToken(cursor).addAllLogNames(returnedList).build();
     ApiFuture<ListLogsResponse> futureResponse = ApiFutures.immediateFuture(response);
-    EasyMock.expect(loggingRpcMock.list(request)).andReturn(futureResponse);
+    EasyMock.expect(loggingRpcMock.listLogs(request)).andReturn(futureResponse);
     EasyMock.replay(loggingRpcMock);
   }
 
@@ -207,8 +207,8 @@ public class LoggingImplTest {
             .build();
     ApiFuture<ListLogsResponse> futureResponse1 = ApiFutures.immediateFuture(response1);
     ApiFuture<ListLogsResponse> futureResponse2 = ApiFutures.immediateFuture(response2);
-    EasyMock.expect(loggingRpcMock.list(request1)).andReturn(futureResponse1);
-    EasyMock.expect(loggingRpcMock.list(request2)).andReturn(futureResponse2);
+    EasyMock.expect(loggingRpcMock.listLogs(request1)).andReturn(futureResponse1);
+    EasyMock.expect(loggingRpcMock.listLogs(request2)).andReturn(futureResponse2);
     EasyMock.replay(loggingRpcMock);
   }
 
@@ -1618,7 +1618,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testListLogs() {
+  public void testListLogsWithLogNames() {
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
     List<String> logNames = ImmutableList.of(LOG_NAME1, LOG_NAME2);
@@ -1630,7 +1630,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testListLogsEmpty() {
+  public void testListLogsWithEmptySet() {
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
     List<String> emptyList = ImmutableList.of();
@@ -1642,7 +1642,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testListLogsNextPage() throws ExecutionException, InterruptedException {
+  public void testListLogsNextPageWithLogNames() throws ExecutionException, InterruptedException {
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
     List<String> logNames1 = ImmutableList.of(LOG_NAME1, LOG_NAME2);
@@ -1659,7 +1659,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testListLogsAsync() throws ExecutionException, InterruptedException {
+  public void testListLogsAsyncWithLogNames() throws ExecutionException, InterruptedException {
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
     List<String> logNames = ImmutableList.of(LOG_NAME1, LOG_NAME2);
@@ -1671,7 +1671,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testListLogsAsyncEmpty() throws ExecutionException, InterruptedException {
+  public void testListLogsAsyncWithEmptySet() throws ExecutionException, InterruptedException {
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
     List<String> emptyList = ImmutableList.of();
@@ -1683,7 +1683,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testListLogsAsyncNextPage() throws ExecutionException, InterruptedException {
+  public void testListLogsAsyncNextPageWithLogNames() throws ExecutionException, InterruptedException {
     EasyMock.replay(rpcFactoryMock);
     logging = options.getService();
     List<String> logNames1 = ImmutableList.of(LOG_NAME1, LOG_NAME2);

--- a/samples/snippets/src/main/java/com/example/logging/ListLogEntries.java
+++ b/samples/snippets/src/main/java/com/example/logging/ListLogEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google Inc.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/com/example/logging/ListLogEntries.java
+++ b/samples/snippets/src/main/java/com/example/logging/ListLogEntries.java
@@ -16,26 +16,33 @@
 
 package com.example.logging;
 
-// [START logging_list_logs]
+// [START logging_list_log_entries]
 import com.google.api.gax.paging.Page;
+import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
+import com.google.cloud.logging.Logging.EntryListOption;
 import com.google.cloud.logging.LoggingOptions;
 
-public class ListLogs {
+public class ListLogEntries {
 
-  public static void main(String... args) throws Exception {
+  public static void main(String[] args) throws Exception {
+    // TODO(developer): Replace the variable value with valid log name before running the sample
+    // or provide it as an argument.
+    String logName = args.length > 0 ? args[0] : "test-log";
 
     LoggingOptions options = LoggingOptions.getDefaultInstance();
     Logging logging = options.getService();
 
-    // List all log names
-    Page<String> logNames = logging.listLogs();
-    while (logNames != null) {
-      for (String logName : logNames.iterateAll()) {
-        System.out.println(logName);
-      }
-      logNames = logNames.getNextPage();
+    String logFilter = "logName=projects/" + options.getProjectId() + "/logs/" + logName;
+
+    // List all log entries
+    Page<LogEntry> entries = logging.listLogEntries(EntryListOption.filter(logFilter));
+    while (entries != null) {
+        for (LogEntry logEntry : entries.iterateAll()) {
+            System.out.println(logEntry);
+        }
+        entries = entries.getNextPage();
     }
   }
 }
-// [END logging_list_logs]
+// [END logging_list_log_entries]

--- a/samples/snippets/src/main/java/com/example/logging/ListLogEntries.java
+++ b/samples/snippets/src/main/java/com/example/logging/ListLogEntries.java
@@ -38,10 +38,10 @@ public class ListLogEntries {
     // List all log entries
     Page<LogEntry> entries = logging.listLogEntries(EntryListOption.filter(logFilter));
     while (entries != null) {
-        for (LogEntry logEntry : entries.iterateAll()) {
-            System.out.println(logEntry);
-        }
-        entries = entries.getNextPage();
+      for (LogEntry logEntry : entries.iterateAll()) {
+        System.out.println(logEntry);
+      }
+      entries = entries.getNextPage();
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/logging/ListLogEntries.java
+++ b/samples/snippets/src/main/java/com/example/logging/ListLogEntries.java
@@ -22,6 +22,10 @@ import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.Logging.EntryListOption;
 import com.google.cloud.logging.LoggingOptions;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
 
 public class ListLogEntries {
 
@@ -33,7 +37,15 @@ public class ListLogEntries {
     LoggingOptions options = LoggingOptions.getDefaultInstance();
     Logging logging = options.getService();
 
-    String logFilter = "logName=projects/" + options.getProjectId() + "/logs/" + logName;
+    // When composing a filter, using indexed fields, such as timestamp, resource.type, logName and
+    // others can help accelerate the results
+    // Full list of indexed fields here: https://cloud.google.com/logging/docs/view/advanced-queries#finding-quickly
+    // This sample restrict the results to only last hour to minimize number of API calls
+    Calendar calendar = Calendar.getInstance();
+    calendar.add(Calendar.HOUR, -1);
+    DateFormat rfc3339 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+    String logFilter = "logName=projects/" + options.getProjectId() + "/logs/" + logName
+        + " AND timestamp>=\"" + rfc3339.format(calendar.getTime()) + "\"";
 
     // List all log entries
     Page<LogEntry> entries = logging.listLogEntries(EntryListOption.filter(logFilter));

--- a/samples/snippets/src/main/java/com/example/logging/ListLogs.java
+++ b/samples/snippets/src/main/java/com/example/logging/ListLogs.java
@@ -39,3 +39,11 @@ public class ListLogs {
   }
 }
 // [END logging_list_logs]
+
+// the following is a temporary location due to exclusive requirement
+// from snippet layout vs. snippet-bot
+
+// [START logging_list_log_entries]
+
+
+// [END logging_list_log_entries]

--- a/samples/snippets/src/main/java/com/example/logging/ListLogs.java
+++ b/samples/snippets/src/main/java/com/example/logging/ListLogs.java
@@ -39,11 +39,3 @@ public class ListLogs {
   }
 }
 // [END logging_list_logs]
-
-// the following is a temporary location due to exclusive requirement
-// from snippet layout vs. snippet-bot
-
-// [START logging_list_log_entries]
-
-
-// [END logging_list_log_entries]

--- a/samples/snippets/src/main/java/com/example/logging/ListLogs.java
+++ b/samples/snippets/src/main/java/com/example/logging/ListLogs.java
@@ -38,7 +38,7 @@ public class ListLogs {
     printLogEntries(logName);
   }
 
-  public static final printLogNames() {
+  public static final void printLogNames() {
     // [START logging_list_logs]
     // Instantiates a client
     LoggingOptions options = LoggingOptions.getDefaultInstance();
@@ -55,7 +55,7 @@ public class ListLogs {
     // [END logging_list_logs]
   }
 
-  public static final printLogEntries(String logName) {
+  public static final void printLogEntries(String logName) {
     // [START logging_list_log_entries]
     // Instantiates a client
     LoggingOptions options = LoggingOptions.getDefaultInstance();

--- a/samples/snippets/src/main/java/com/example/logging/LogEntryWriteHttpRequest.java
+++ b/samples/snippets/src/main/java/com/example/logging/LogEntryWriteHttpRequest.java
@@ -57,7 +57,7 @@ public class LogEntryWriteHttpRequest {
 
       // Writes the log entry asynchronously
       logging.write(Collections.singleton(logEntry));
-      System.out.printf("Logged: %s%n", payLoad);
+      System.out.printf("Logged: %s", payLoad);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/logging/QuickstartSample.java
+++ b/samples/snippets/src/main/java/com/example/logging/QuickstartSample.java
@@ -26,8 +26,8 @@ import com.google.cloud.logging.Severity;
 import java.util.Collections;
 
 /**
- * This sample demonstrates writing logs using the Cloud Logging API. The library also offers
- * a java.util.logging Handler `com.google.cloud.logging.LoggingHandler` Logback integration is also
+ * This sample demonstrates writing logs using the Cloud Logging API. The library also offers a
+ * java.util.logging Handler `com.google.cloud.logging.LoggingHandler` Logback integration is also
  * available :
  * https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-contrib/google-cloud-logging-logback
  * Using the java.util.logging handler / Logback appender should be preferred to using the API

--- a/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
+++ b/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
@@ -87,8 +87,9 @@ public class LoggingIT {
     bout.reset();
 
     // Check for mocked STDOUT having data
+    String[] args = new String[] {TEST_LOG};
     while (bout.toString().isEmpty()) {
-      ListLogs.printLogEntries(TEST_LOG);
+      ListLogEntries.main(args);
       Thread.sleep(5000);
     }
     assertThat(bout.toString().contains(STRING_PAYLOAD2)).isTrue();
@@ -110,8 +111,9 @@ public class LoggingIT {
     bout.reset();
 
     // Check for mocked STDOUT having data
+    String[] args = new String[] {TEST_LOG};
     while (bout.toString().isEmpty()) {
-      ListLogs.printLogEntries(TEST_LOG);
+      ListLogEntries.main(args);
       Thread.sleep(5000);
     }
 
@@ -121,8 +123,8 @@ public class LoggingIT {
   }
 
   @Test(timeout = 60000)
-  public void testListLogNames() throws Exception {
-    ListLogs.printLogNames();
+  public void testListLogNames_shouldPass() throws Exception {
+    ListLogs.main();
     // Check for mocked STDOUT having data
     while (bout.toString().isEmpty()) {
       Thread.sleep(5000);

--- a/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
+++ b/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
@@ -120,7 +120,7 @@ public class LoggingIT {
   }
 
   @Test(timeout = 60000)
-  public void testListLogNames() {
+  public void testListLogNames() throws Exception {
     QuickstartSample.main(TEST_LOG);
     ListLogs.printLogNames();
     // Check for mocked STDOUT having data

--- a/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
+++ b/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
@@ -39,6 +39,7 @@ import org.junit.runners.JUnit4;
 public class LoggingIT {
 
   private static final String TEST_LOG = "test-log";
+  private static final String GOOGLEAPIS_AUDIT_LOGNAME = "cloudaudit.googleapis.com%2Factivity";
   private static final String STRING_PAYLOAD = "Hello, world!";
   private static final String STRING_PAYLOAD2 = "Hello world again";
 
@@ -85,9 +86,9 @@ public class LoggingIT {
     logging.flush();
     bout.reset();
 
-    ListLogs.main(TEST_LOG);
     // Check for mocked STDOUT having data
     while (bout.toString().isEmpty()) {
+      ListLogs.printLogEntries(TEST_LOG);
       Thread.sleep(5000);
     }
     assertThat(bout.toString().contains(STRING_PAYLOAD2)).isTrue();
@@ -108,9 +109,9 @@ public class LoggingIT {
     assertThat(got).contains(String.format("Logged: %s", STRING_PAYLOAD));
     bout.reset();
 
-    ListLogs.printLogEntries(TEST_LOG);
     // Check for mocked STDOUT having data
     while (bout.toString().isEmpty()) {
+      ListLogs.printLogEntries(TEST_LOG);
       Thread.sleep(5000);
     }
 
@@ -121,12 +122,12 @@ public class LoggingIT {
 
   @Test(timeout = 60000)
   public void testListLogNames() throws Exception {
-    QuickstartSample.main(TEST_LOG);
     ListLogs.printLogNames();
     // Check for mocked STDOUT having data
     while (bout.toString().isEmpty()) {
       Thread.sleep(5000);
     }
-    assertThat(bout.toString().contains(TEST_LOG)).isTrue();
+
+    assertThat(bout.toString().contains(GOOGLEAPIS_AUDIT_LOGNAME)).isTrue();
   }
 }


### PR DESCRIPTION
Clean up the duplicated region tag logging_list_log_entries that was introduced by #602 in order to migrate the region tag into the new file