### PR TITLE
chore(doc): fix duplicated region tag

### DIFF
--- a/samples/snippets/src/main/java/com/example/logging/ListLogs.java
+++ b/samples/snippets/src/main/java/com/example/logging/ListLogs.java
@@ -39,11 +39,3 @@ public class ListLogs {
   }
 }
 // [END logging_list_logs]
-
-// the following is a temporary location due to exclusive requirement
-// from snippet layout vs. snippet-bot
-
-// [START logging_list_log_entries]
-
-
-// [END logging_list_log_entries]


### PR DESCRIPTION
Removes duplicated region tag `logging_list_log_entries` from ListLogs.java

The #602 introduced duplicated region tag `logging_list_log_entries` in two files: ListLogs.java and ListLogEntries.java. It was done to avoid breaking DevSite build as part of the effort to move list log entries snippet into the new file.

This PR resolves the duplication by removing the tag from ListLogs.java.