### PR TITLE
ci: update CI to use maven 3.8.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,9 @@ jobs:
       matrix:
         java: [8, 11]
     steps:
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
@@ -22,6 +25,9 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
@@ -36,6 +42,9 @@ jobs:
       matrix:
         java: [8, 11]
     steps:
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
@@ -45,6 +54,9 @@ jobs:
   linkage-monitor:
     runs-on: ubuntu-latest
     steps:
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
@@ -58,6 +70,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
@@ -69,6 +84,9 @@ jobs:
   clirr:
     runs-on: ubuntu-latest
     steps:
+    - uses: stCarolas/setup-maven@v4
+      with:
+        maven-version: 3.8.1
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
Gitbub Action updated LTS(18.04, 20.04) versions of Github-Hosted runners for Ubuntu with the latest version of Apache Maven. The new version of Ubuntu has Apache Maven 3.8.2 which is incompatible with flatten-maven-plugin:1.2.7. This caused all github actions using the latest Ubuntu version to fail with this error.

The immediate solution is to use this community action to install maven 3.8.1 at runtime.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-logging/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
