### PR TITLE
doc: add information about writing log entry modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,27 @@ LogEntry firstEntry = LogEntry.newBuilder(StringPayload.of("message"))
 logging.write(Collections.singleton(firstEntry));
 ```
 
+The library supports writing log entries synchronously and asynchronously.
+In the synchronous mode each call to `write()` method results in a consequent call to Logging API to write a log entry.
+In the asynchronous mode the call(s) to Logging API takes place asynchronously and few calls to `write()` method may be batched together to compose a single call to Logging API.
+The default mode of writing is asynchronous.
+It can be configured in the `java.util.logging` handler [configuration file](https://cloud.google.com/logging/docs/setup/java#javautillogging_configuration):
+
+```
+com.google.cloud.logging.LoggingHandler.synchronicity=SYNC
+```
+
+or in the code after initiating an instance of `Logging` by calling:
+
+```java
+logging.setWriteSynchronicity(Synchronicity.SYNC);
+```
+
+NOTE:
+> Writing log entries asynchronously in some Google Cloud managed environments (e.g. Cloud Functions)
+> may lead to unexpected results such as absense of expected log entries or abnormal program execution.
+> To avoid these unexpected results, it is recommended to use synchronous mode.
+
 #### Listing log entries
 
 With Logging you can also list log entries that have been previously written. Add the following


### PR DESCRIPTION
provide an explanation about synchronous and asynchronous modes for writing log entries and how the mode can be configured.

Fixes #665 
