### PR TITLE
chore(fix): imrpove exec time of flaky test

### DIFF
--- a/samples/snippets/src/main/java/com/example/logging/ListLogEntries.java
+++ b/samples/snippets/src/main/java/com/example/logging/ListLogEntries.java
@@ -26,7 +26,6 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
-
 public class ListLogEntries {
 
   public static void main(String[] args) throws Exception {
@@ -39,13 +38,20 @@ public class ListLogEntries {
 
     // When composing a filter, using indexed fields, such as timestamp, resource.type, logName and
     // others can help accelerate the results
-    // Full list of indexed fields here: https://cloud.google.com/logging/docs/view/advanced-queries#finding-quickly
+    // Full list of indexed fields here:
+    // https://cloud.google.com/logging/docs/view/advanced-queries#finding-quickly
     // This sample restrict the results to only last hour to minimize number of API calls
     Calendar calendar = Calendar.getInstance();
     calendar.add(Calendar.HOUR, -1);
     DateFormat rfc3339 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-    String logFilter = "logName=projects/" + options.getProjectId() + "/logs/" + logName
-        + " AND timestamp>=\"" + rfc3339.format(calendar.getTime()) + "\"";
+    String logFilter =
+        "logName=projects/"
+            + options.getProjectId()
+            + "/logs/"
+            + logName
+            + " AND timestamp>=\""
+            + rfc3339.format(calendar.getTime())
+            + "\"";
 
     // List all log entries
     Page<LogEntry> entries = logging.listLogEntries(EntryListOption.filter(logFilter));

--- a/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
+++ b/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
@@ -16,16 +16,16 @@
 
 package com.example.logging;
 
+import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
 import static com.google.common.truth.Truth.assertThat;
 
-import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
 import com.google.cloud.MonitoredResource;
 import com.google.cloud.logging.HttpRequest;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.LoggingOptions;
-import com.google.cloud.logging.Synchronicity;
 import com.google.cloud.logging.Payload.StringPayload;
+import com.google.cloud.logging.Synchronicity;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Collections;

--- a/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
+++ b/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
@@ -18,11 +18,13 @@ package com.example.logging;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import static com.google.cloud.logging.testing.RemoteLoggingHelper.formatForTest;
 import com.google.cloud.MonitoredResource;
 import com.google.cloud.logging.HttpRequest;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.LoggingOptions;
+import com.google.cloud.logging.Synchronicity;
 import com.google.cloud.logging.Payload.StringPayload;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -38,7 +40,7 @@ import org.junit.runners.JUnit4;
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class LoggingIT {
 
-  private static final String TEST_LOG = "test-log";
+  private static final String TEST_LOG = formatForTest("test-log");
   private static final String GOOGLEAPIS_AUDIT_LOGNAME = "cloudaudit.googleapis.com%2Factivity";
   private static final String STRING_PAYLOAD = "Hello, world!";
   private static final String STRING_PAYLOAD2 = "Hello world again";
@@ -74,13 +76,14 @@ public class LoggingIT {
   }
 
   @Test(timeout = 60000)
-  public void testWriteAndListLogs() throws Exception {
+  public void testListLogEntries() throws Exception {
     // write a log entry
     LogEntry entry =
         LogEntry.newBuilder(StringPayload.of(STRING_PAYLOAD2))
             .setLogName(TEST_LOG)
             .setResource(MonitoredResource.newBuilder("global").build())
             .build();
+    logging.setWriteSynchronicity(Synchronicity.SYNC);
     logging.write(Collections.singleton(entry));
     // flush out log immediately
     logging.flush();


### PR DESCRIPTION
implement writing log(s) synchronously.
enforce uniqueness of the log name to avoid conflict with parallel executions.
rename the test to follow test<SampleClassName> notation.

Fix #657 
