### PR TITLE
Simplify initialization of LoggingHandler.logger.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,20 +51,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:23.1.0')
+implementation platform('com.google.cloud:libraries-bom:24.0.0')
 
 implementation 'com.google.cloud:google-cloud-logging'
 ```
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-logging:3.2.0'
+implementation 'com.google.cloud:google-cloud-logging:3.3.0'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.2.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.3.0"
 ```
 
 ## Authentication

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
@@ -220,6 +220,7 @@ public class LoggingHandlerTest {
   public void setUp() {
     logging = EasyMock.createMock(Logging.class);
     options = EasyMock.createStrictMock(LoggingOptions.class);
+    expect(options.getService()).andReturn(logging);
   }
 
   @After
@@ -236,7 +237,6 @@ public class LoggingHandlerTest {
   @Test
   public void testPublishLevels() {
     expect(options.getProjectId()).andReturn(PROJECT).anyTimes();
-    expect(options.getService()).andReturn(logging);
     logging.setFlushSeverity(Severity.ERROR);
     expectLastCall().once();
     logging.setWriteSynchronicity(Synchronicity.ASYNC);
@@ -291,7 +291,6 @@ public class LoggingHandlerTest {
   @Test
   public void testPublishCustomResource() {
     expect(options.getProjectId()).andReturn(PROJECT).anyTimes();
-    expect(options.getService()).andReturn(logging);
     logging.setFlushSeverity(Severity.ERROR);
     expectLastCall().once();
     logging.setWriteSynchronicity(Synchronicity.ASYNC);
@@ -313,7 +312,6 @@ public class LoggingHandlerTest {
   @Test
   public void testPublishKubernetesContainerResource() {
     expect(options.getProjectId()).andReturn(PROJECT).anyTimes();
-    expect(options.getService()).andReturn(logging);
     logging.setFlushSeverity(Severity.ERROR);
     expectLastCall().once();
     logging.setWriteSynchronicity(Synchronicity.ASYNC);
@@ -348,7 +346,6 @@ public class LoggingHandlerTest {
   @Test
   public void testEnhancedLogEntry() {
     expect(options.getProjectId()).andReturn(PROJECT).anyTimes();
-    expect(options.getService()).andReturn(logging);
     MonitoredResource resource = MonitoredResource.of("custom", ImmutableMap.<String, String>of());
     logging.setFlushSeverity(Severity.ERROR);
     expectLastCall().once();
@@ -378,7 +375,6 @@ public class LoggingHandlerTest {
   @Test
   public void testTraceEnhancedLogEntry() {
     expect(options.getProjectId()).andReturn(PROJECT).anyTimes();
-    expect(options.getService()).andReturn(logging);
     MonitoredResource resource = MonitoredResource.of("custom", ImmutableMap.<String, String>of());
     logging.setFlushSeverity(Severity.ERROR);
     expectLastCall().once();
@@ -403,7 +399,6 @@ public class LoggingHandlerTest {
   @Test
   public void testReportWriteError() {
     expect(options.getProjectId()).andReturn(PROJECT).anyTimes();
-    expect(options.getService()).andReturn(logging);
     RuntimeException ex = new RuntimeException();
     logging.setFlushSeverity(Severity.ERROR);
     expectLastCall().once();
@@ -427,7 +422,6 @@ public class LoggingHandlerTest {
   @Test
   public void testReportFlushError() {
     expect(options.getProjectId()).andReturn(PROJECT).anyTimes();
-    expect(options.getService()).andReturn(logging);
     RuntimeException ex = new RuntimeException();
     logging.setFlushSeverity(Severity.ERROR);
     expectLastCall().once();
@@ -454,7 +448,6 @@ public class LoggingHandlerTest {
   @Test
   public void testReportFormatError() {
     expect(options.getProjectId()).andReturn(PROJECT).anyTimes();
-    expect(options.getService()).andReturn(logging);
     logging.setFlushSeverity(Severity.ERROR);
     expectLastCall().once();
     logging.setWriteSynchronicity(Synchronicity.ASYNC);
@@ -480,7 +473,6 @@ public class LoggingHandlerTest {
   // @Test
   public void testFlushLevel() {
     expect(options.getProjectId()).andReturn(PROJECT).anyTimes();
-    expect(options.getService()).andReturn(logging);
     logging.setFlushSeverity(Severity.ERROR);
     expectLastCall().once();
     logging.setWriteSynchronicity(Synchronicity.ASYNC);
@@ -508,7 +500,6 @@ public class LoggingHandlerTest {
   @Test
   public void testSyncWrite() {
     expect(options.getProjectId()).andReturn(PROJECT).anyTimes();
-    expect(options.getService()).andReturn(logging);
     LogEntry entry =
         LogEntry.newBuilder(Payload.StringPayload.of(MESSAGE))
             .setSeverity(Severity.DEBUG)
@@ -539,7 +530,6 @@ public class LoggingHandlerTest {
   @Test
   public void testAddHandler() {
     expect(options.getProjectId()).andReturn(PROJECT).anyTimes();
-    expect(options.getService()).andReturn(logging);
     logging.setFlushSeverity(Severity.ERROR);
     expectLastCall().once();
     logging.setWriteSynchronicity(Synchronicity.ASYNC);
@@ -565,7 +555,6 @@ public class LoggingHandlerTest {
   @Test
   public void testClose() throws Exception {
     expect(options.getProjectId()).andReturn(PROJECT).anyTimes();
-    expect(options.getService()).andReturn(logging);
     logging.setFlushSeverity(Severity.ERROR);
     expectLastCall().once();
     logging.setWriteSynchronicity(Synchronicity.ASYNC);
@@ -579,7 +568,6 @@ public class LoggingHandlerTest {
     handler.setLevel(Level.ALL);
     handler.setFormatter(new TestFormatter());
     handler.publish(newLogRecord(Level.FINEST, MESSAGE));
-    handler.close();
     handler.close();
   }
 }


### PR DESCRIPTION
getLogging() was called in the constructor of LoggingHandler. So, there's no reason to have lazy initialization for the logger.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-logging/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
