### PR TITLE
feat: implement revised version of the monitored resource type discovery and metadata population

### DIFF
--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/HttpRequest.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/HttpRequest.java
@@ -69,7 +69,7 @@ public final class HttpRequest implements Serializable {
         };
 
     private static final StringEnumType<RequestMethod> type =
-        new StringEnumType(RequestMethod.class, CONSTRUCTOR);
+        new StringEnumType<RequestMethod>(RequestMethod.class, CONSTRUCTOR);
 
     public static final RequestMethod GET = type.createAndRegister("GET");
     public static final RequestMethod HEAD = type.createAndRegister("HEAD");

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
@@ -277,7 +277,7 @@ public class LogEntry implements Serializable {
      *
      * @see <a href="https://cloud.google.com/logging/docs/view/logs_index">Log Entries and Logs</a>
      */
-    public Builder setPayload(Payload payload) {
+    public Builder setPayload(Payload<?> payload) {
       this.payload = payload;
       return this;
     }
@@ -434,7 +434,7 @@ public class LogEntry implements Serializable {
    * @see <a href="https://cloud.google.com/logging/docs/view/logs_index">Log Entries and Logs</a>
    */
   @SuppressWarnings("unchecked")
-  public <T extends Payload> T getPayload() {
+  public <T extends Payload<?>> T getPayload() {
     return (T) payload;
   }
 

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingHandler.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingHandler.java
@@ -22,7 +22,6 @@ import com.google.cloud.MonitoredResource;
 import com.google.cloud.logging.Logging.WriteOption;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
 import java.time.Instant;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -37,12 +36,11 @@ import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 
 /**
- * A logging handler that outputs logs generated with
- * {@link java.util.logging.Logger} to Cloud Logging.
+ * A logging handler that outputs logs generated with {@link java.util.logging.Logger} to Cloud
+ * Logging.
  *
- * <p>
- * Java logging levels (see {@link java.util.logging.Level}) are mapped to the
- * following Google Cloud Logging severities:
+ * <p>Java logging levels (see {@link java.util.logging.Level}) are mapped to the following Google
+ * Cloud Logging severities:
  *
  * <table summary="Mapping of Java logging level to Cloud Logging severities">
  * <tr>
@@ -79,54 +77,41 @@ import java.util.logging.SimpleFormatter;
  * </tr>
  * </table>
  *
- * <p>
- * Original Java logging levels are added as labels (with {@code levelName} and
- * {@code
- * levelValue} keys, respectively) to the corresponding Cloud Logging
- * {@link LogEntry}. You can read entry labels using
- * {@link LogEntry#getLabels()}. To use logging levels that correspond to Cloud
+ * <p>Original Java logging levels are added as labels (with {@code levelName} and {@code
+ * levelValue} keys, respectively) to the corresponding Cloud Logging {@link LogEntry}. You can read
+ * entry labels using {@link LogEntry#getLabels()}. To use logging levels that correspond to Cloud
  * Logging severities you can use {@link LoggingLevel}.
  *
- * <p>
- * <b>Configuration</b>: By default each {@code LoggingHandler} is initialized
- * using the following {@code LogManager} configuration properties (that you can
- * set in the {@code
- * logging.properties} file). If properties are not defined (or have invalid
- * values) then the specified default values are used.
+ * <p><b>Configuration</b>: By default each {@code LoggingHandler} is initialized using the
+ * following {@code LogManager} configuration properties (that you can set in the {@code
+ * logging.properties} file). If properties are not defined (or have invalid values) then the
+ * specified default values are used.
  *
  * <ul>
- * <li>{@code com.google.cloud.logging.LoggingHandler.log} the log name
- * (defaults to {@code
+ *   <li>{@code com.google.cloud.logging.LoggingHandler.log} the log name (defaults to {@code
  *       java.log}).
- * <li>{@code com.google.cloud.logging.LoggingHandler.level} specifies the
- * default level for the handler (defaults to {@code Level.INFO}).
- * <li>{@code com.google.cloud.logging.LoggingHandler.filter} specifies the name
- * of a {@link Filter} class to use (defaults to no filter).
- * <li>{@code com.google.cloud.logging.LoggingHandler.formatter} specifies the
- * name of a {@link Formatter} class to use (defaults to
- * {@link SimpleFormatter}).
- * <li>{@code com.google.cloud.logging.LoggingHandler.flushLevel} specifies the
- * flush log level. When a log with this level is published, logs are
- * transmitted to the Cloud Logging service (defaults to
- * {@link LoggingLevel#ERROR}).
- * <li>{@code com.google.cloud.logging.LoggingHandler.enhancers} specifies a
- * comma separated list of {@link LoggingEnhancer} classes. This handler will
- * call each enhancer list whenever it builds a {@link LogEntry} instance
- * (defaults to empty list).
- * <li>{@code com.google.cloud.logging.LoggingHandler.resourceType} the type
- * name to use when creating the default {@link MonitoredResource} (defaults to
- * auto-detected resource type, else "global").
- * <li>{@code com.google.cloud.logging.Synchronicity} the synchronicity of the
- * write method to use to write logs to the Cloud Logging service (defaults to
- * {@link Synchronicity#ASYNC}).
+ *   <li>{@code com.google.cloud.logging.LoggingHandler.level} specifies the default level for the
+ *       handler (defaults to {@code Level.INFO}).
+ *   <li>{@code com.google.cloud.logging.LoggingHandler.filter} specifies the name of a {@link
+ *       Filter} class to use (defaults to no filter).
+ *   <li>{@code com.google.cloud.logging.LoggingHandler.formatter} specifies the name of a {@link
+ *       Formatter} class to use (defaults to {@link SimpleFormatter}).
+ *   <li>{@code com.google.cloud.logging.LoggingHandler.flushLevel} specifies the flush log level.
+ *       When a log with this level is published, logs are transmitted to the Cloud Logging service
+ *       (defaults to {@link LoggingLevel#ERROR}).
+ *   <li>{@code com.google.cloud.logging.LoggingHandler.enhancers} specifies a comma separated list
+ *       of {@link LoggingEnhancer} classes. This handler will call each enhancer list whenever it
+ *       builds a {@link LogEntry} instance (defaults to empty list).
+ *   <li>{@code com.google.cloud.logging.LoggingHandler.resourceType} the type name to use when
+ *       creating the default {@link MonitoredResource} (defaults to auto-detected resource type,
+ *       else "global").
+ *   <li>{@code com.google.cloud.logging.Synchronicity} the synchronicity of the write method to use
+ *       to write logs to the Cloud Logging service (defaults to {@link Synchronicity#ASYNC}).
  * </ul>
  *
- * <p>
- * To add a {@code LoggingHandler} to an existing {@link Logger} and be sure to
- * avoid infinite recursion when logging, use the
- * {@link #addHandler(Logger, LoggingHandler)} method. Alternatively you can add
- * the handler via {@code logging.properties}. For example using the following
- * line:
+ * <p>To add a {@code LoggingHandler} to an existing {@link Logger} and be sure to avoid infinite
+ * recursion when logging, use the {@link #addHandler(Logger, LoggingHandler)} method. Alternatively
+ * you can add the handler via {@code logging.properties}. For example using the following line:
  *
  * <pre>
  * {@code com.example.mypackage.handlers=com.google.cloud.logging.LoggingHandler}
@@ -171,7 +156,7 @@ public class LoggingHandler extends Handler {
   /**
    * Creates a handler that publishes messages to Cloud Logging.
    *
-   * @param log     the name of the log to which log entries are written
+   * @param log the name of the log to which log entries are written
    * @param options options for the Cloud Logging service
    */
   public LoggingHandler(String log, LoggingOptions options) {
@@ -181,11 +166,10 @@ public class LoggingHandler extends Handler {
   /**
    * Creates a handler that publishes messages to Cloud Logging.
    *
-   * @param log               the name of the log to which log entries are written
-   * @param options           options for the Cloud Logging service
-   * @param monitoredResource the monitored resource to which log entries refer.
-   *                          If it is null then a default resource is created
-   *                          based on the project ID and deployment environment.
+   * @param log the name of the log to which log entries are written
+   * @param options options for the Cloud Logging service
+   * @param monitoredResource the monitored resource to which log entries refer. If it is null then
+   *     a default resource is created based on the project ID and deployment environment.
    */
   public LoggingHandler(String log, LoggingOptions options, MonitoredResource monitoredResource) {
     this(log, options, monitoredResource, null);
@@ -194,16 +178,17 @@ public class LoggingHandler extends Handler {
   /**
    * Creates a handler that publishes messages to Cloud Logging.
    *
-   * @param log               the name of the log to which log entries are written
-   * @param options           options for the Cloud Logging service
-   * @param monitoredResource the monitored resource to which log entries refer.
-   *                          If it is null then a default resource is created
-   *                          based on the project ID and deployment environment.
-   * @param enhancers         List of {@link LoggingEnhancer} instances used to
-   *                          enhance any{@link LogEntry} instances built by this
-   *                          handler.
+   * @param log the name of the log to which log entries are written
+   * @param options options for the Cloud Logging service
+   * @param monitoredResource the monitored resource to which log entries refer. If it is null then
+   *     a default resource is created based on the project ID and deployment environment.
+   * @param enhancers List of {@link LoggingEnhancer} instances used to enhance any{@link LogEntry}
+   *     instances built by this handler.
    */
-  public LoggingHandler(String log, LoggingOptions options, MonitoredResource monitoredResource,
+  public LoggingHandler(
+      String log,
+      LoggingOptions options,
+      MonitoredResource monitoredResource,
       List<LoggingEnhancer> enhancers) {
     try {
       loggingOptions = options != null ? options : LoggingOptions.getDefaultInstance();
@@ -216,19 +201,30 @@ public class LoggingHandler extends Handler {
       flushLevel = config.getFlushLevel();
       String logName = log != null ? log : config.getLogName();
 
-      MonitoredResource resource = firstNonNull(monitoredResource,
-          config.getMonitoredResource(loggingOptions.getProjectId()));
-      defaultWriteOptions = new WriteOption[] { WriteOption.logName(logName), WriteOption.resource(resource),
-          WriteOption.labels(ImmutableMap.of(LEVEL_NAME_KEY, baseLevel.getName(), LEVEL_VALUE_KEY,
-              String.valueOf(baseLevel.intValue()))) };
+      MonitoredResource resource =
+          firstNonNull(
+              monitoredResource, config.getMonitoredResource(loggingOptions.getProjectId()));
+      defaultWriteOptions =
+          new WriteOption[] {
+            WriteOption.logName(logName),
+            WriteOption.resource(resource),
+            WriteOption.labels(
+                ImmutableMap.of(
+                    LEVEL_NAME_KEY,
+                    baseLevel.getName(),
+                    LEVEL_VALUE_KEY,
+                    String.valueOf(baseLevel.intValue())))
+          };
 
       getLogging().setFlushSeverity(severityFor(flushLevel));
       getLogging().setWriteSynchronicity(config.getSynchronicity());
 
       this.enhancers = new LinkedList<>();
 
-      List<LoggingEnhancer> enhancersParam = firstNonNull(enhancers,
-          firstNonNull(config.getEnhancers(), Collections.<LoggingEnhancer>emptyList()));
+      List<LoggingEnhancer> enhancersParam =
+          firstNonNull(
+              enhancers,
+              firstNonNull(config.getEnhancers(), Collections.<LoggingEnhancer>emptyList()));
 
       this.enhancers.addAll(enhancersParam);
 
@@ -275,11 +271,15 @@ public class LoggingHandler extends Handler {
   private LogEntry logEntryFor(LogRecord record) throws Exception {
     String payload = getFormatter().format(record);
     Level level = record.getLevel();
-    LogEntry.Builder builder = LogEntry.newBuilder(Payload.StringPayload.of(payload))
-        .setTimestamp(Instant.ofEpochMilli(record.getMillis())).setSeverity(severityFor(level));
+    LogEntry.Builder builder =
+        LogEntry.newBuilder(Payload.StringPayload.of(payload))
+            .setTimestamp(Instant.ofEpochMilli(record.getMillis()))
+            .setSeverity(severityFor(level));
 
     if (!baseLevel.equals(level)) {
-      builder.addLabel("levelName", level.getName()).addLabel("levelValue", String.valueOf(level.intValue()));
+      builder
+          .addLabel("levelName", level.getName())
+          .addLabel("levelValue", String.valueOf(level.intValue()));
     }
 
     for (LoggingEnhancer enhancer : enhancers) {
@@ -340,9 +340,9 @@ public class LoggingHandler extends Handler {
   }
 
   /**
-   * Adds the provided {@code LoggingHandler} to {@code logger}. Use this method
-   * to register Cloud Logging handlers instead of
-   * {@link Logger#addHandler(Handler)} to avoid infinite recursion when logging.
+   * Adds the provided {@code LoggingHandler} to {@code logger}. Use this method to register Cloud
+   * Logging handlers instead of {@link Logger#addHandler(Handler)} to avoid infinite recursion when
+   * logging.
    */
   public static void addHandler(Logger logger, LoggingHandler handler) {
     logger.addHandler(handler);
@@ -354,29 +354,29 @@ public class LoggingHandler extends Handler {
     }
 
     switch (level.intValue()) {
-    // FINEST
-    case 300:
-      return Severity.DEBUG;
-    // FINER
-    case 400:
-      return Severity.DEBUG;
-    // FINE
-    case 500:
-      return Severity.DEBUG;
-    // CONFIG
-    case 700:
-      return Severity.INFO;
-    // INFO
-    case 800:
-      return Severity.INFO;
-    // WARNING
-    case 900:
-      return Severity.WARNING;
-    // SEVERE
-    case 1000:
-      return Severity.ERROR;
-    default:
-      return Severity.DEFAULT;
+        // FINEST
+      case 300:
+        return Severity.DEBUG;
+        // FINER
+      case 400:
+        return Severity.DEBUG;
+        // FINE
+      case 500:
+        return Severity.DEBUG;
+        // CONFIG
+      case 700:
+        return Severity.INFO;
+        // INFO
+      case 800:
+        return Severity.INFO;
+        // WARNING
+      case 900:
+        return Severity.WARNING;
+        // SEVERE
+      case 1000:
+        return Severity.ERROR;
+      default:
+        return Severity.DEFAULT;
     }
   }
 

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingOptions.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingOptions.java
@@ -98,6 +98,7 @@ public class LoggingOptions extends ServiceOptions<Logging, LoggingOptions> {
     super(LoggingFactory.class, LoggingRpcFactory.class, builder, new LoggingDefaults());
   }
 
+  @SuppressWarnings("serial")
   private static class LoggingDefaults implements ServiceDefaults<Logging, LoggingOptions> {
 
     @Override

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/MonitoredResourceUtil.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/MonitoredResourceUtil.java
@@ -37,6 +37,7 @@ import java.util.Map;
 public class MonitoredResourceUtil {
 
   private static final String APPENGINE_LABEL_PREFIX = "appengine.googleapis.com/";
+  private static final String CLUSTER_NAME_ATTRIBUTE = "instance/attributes/cluster-name";
   private static final String K8S_POD_NAMESPACE_PATH =
       "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
   private static final String FLEX_ENV = "flex";
@@ -188,7 +189,7 @@ public class MonitoredResourceUtil {
         && getter.getEnv("FUNCTION_TARGET") != null) {
       return Resource.CloudFunction;
     }
-    if (getter.getAttribute("instance/attributes/cluster-name") != null) {
+    if (getter.getAttribute(CLUSTER_NAME_ATTRIBUTE) != null) {
       return Resource.K8sContainer;
     }
     if (getter.getAttribute("instance/preempted") != null
@@ -216,7 +217,7 @@ public class MonitoredResourceUtil {
 
     switch (label) {
       case ClusterName:
-        value = getter.getAttribute("instance/attributes/cluster-name");
+        value = getter.getAttribute(CLUSTER_NAME_ATTRIBUTE);
         break;
       case ConfigurationName:
         value = getter.getEnv("K_CONFIGURATION");

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/MonitoredResourceUtil.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/MonitoredResourceUtil.java
@@ -18,7 +18,6 @@ package com.google.cloud.logging;
 
 import com.google.cloud.MetadataConfig;
 import com.google.cloud.MonitoredResource;
-import com.google.cloud.ServiceOptions;
 import com.google.cloud.logging.LogEntry.Builder;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMultimap;
@@ -38,19 +37,24 @@ import java.util.Map;
  */
 public class MonitoredResourceUtil {
 
+  static String K8S_POD_NAMESPACE_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+  static String FLEX_ENV = "flex";
+  static String STD_ENV = "standard";
+
   private enum Label {
-    AppId("app_id"),
     ClusterName("cluster_name"),
+    ConfigurationName("configuration_name"),
     ContainerName("container_name"),
+    Env("env"),
+    FunctionName("function_name"),
     InstanceId("instance_id"),
     InstanceName("instance_name"),
     Location("location"),
     ModuleId("module_id"),
-    NamespaceId("namespace_id"),
     NamespaceName("namespace_name"),
-    PodId("pod_id"),
     PodName("pod_name"),
     ProjectId("project_id"),
+    Region("region"),
     RevisionName("revision_name"),
     ServiceName("service_name"),
     VersionId("version_id"),
@@ -69,9 +73,8 @@ public class MonitoredResourceUtil {
 
   private enum Resource {
     CloudRun("cloud_run_revision"),
-    Container("container"),
-    GaeAppFlex("gae_app_flex"),
-    GaeAppStandard("gae_app_standard"),
+    CloudFunction("cloud_function"),
+    AppEngine("gae_app"),
     GceInstance("gce_instance"),
     K8sContainer("k8s_container"),
     Global("global");
@@ -91,17 +94,15 @@ public class MonitoredResourceUtil {
 
   private static ImmutableMultimap<String, Label> resourceTypeWithLabels =
       ImmutableMultimap.<String, Label>builder()
+          .putAll(Resource.CloudFunction.getKey(), Label.FunctionName, Label.Region)
           .putAll(
-              Resource.Container.getKey(),
-              Label.ClusterName,
-              Label.ContainerName,
-              Label.InstanceId,
-              Label.NamespaceId,
-              Label.PodId,
-              Label.Zone)
-          .putAll(Resource.CloudRun.getKey(), Label.RevisionName, Label.ServiceName, Label.Location)
-          .putAll(Resource.GaeAppFlex.getKey(), Label.ModuleId, Label.VersionId, Label.Zone)
-          .putAll(Resource.GaeAppStandard.getKey(), Label.ModuleId, Label.VersionId)
+              Resource.CloudRun.getKey(),
+              Label.RevisionName,
+              Label.ServiceName,
+              Label.Location,
+              Label.ConfigurationName)
+          .putAll(
+              Resource.AppEngine.getKey(), Label.ModuleId, Label.VersionId, Label.Zone, Label.Env)
           .putAll(Resource.GceInstance.getKey(), Label.InstanceId, Label.Zone)
           .putAll(
               Resource.K8sContainer.getKey(),
@@ -112,22 +113,35 @@ public class MonitoredResourceUtil {
               Label.ContainerName)
           .build();
 
+  private static Map<String, MonitoredResource> cachedMonitoredResources = new HashMap<>();
+  
   private MonitoredResourceUtil() {}
 
-  /* Return a self-configured monitored Resource. */
-  public static MonitoredResource getResource(String projectId, String resourceTypeParam) {
-    String resourceType = resourceTypeParam;
+  /**
+   * Build {@link MonitoredResource} based on detected resource type and populate it with labels
+   * following Monitored Resource Types documentation.
+   *
+   * @param projectId A string defining the project id
+   * @param resourceType A custom resource type
+   * @return the created {@link MonitoredResource}
+   * @see <a href="https://cloud.google.com/monitoring/api/resources">Monitored resource Types</a>
+   */
+  public static MonitoredResource getResource(String projectId, String resourceType) {
+    if (projectId == null || projectId.trim().isEmpty()) {
+      projectId = MetadataConfig.getProjectId();
+    }
+
+    MonitoredResource result = cachedMonitoredResources.get(projectId + "/" + resourceType);
+    if (result != null) {
+      return result;
+    }
+
     if (Strings.isNullOrEmpty(resourceType)) {
-      Resource detectedResourceType = getAutoDetectedResourceType();
+      Resource detectedResourceType = detectResourceType();
       resourceType = detectedResourceType.getKey();
     }
-    // Currently, "gae_app" is the supported logging Resource type, but we distinguish
-    // between "gae_app_flex", "gae_app_standard" to support zone id, instance name logging on flex
-    // VMs.
-    // Hence, "gae_app_flex", "gae_app_standard" are trimmed to "gae_app"
-    String resourceName = resourceType.startsWith("gae_app") ? "gae_app" : resourceType;
     MonitoredResource.Builder builder =
-        MonitoredResource.newBuilder(resourceName).addLabel(Label.ProjectId.getKey(), projectId);
+        MonitoredResource.newBuilder(resourceType).addLabel(Label.ProjectId.getKey(), projectId);
 
     for (Label label : resourceTypeWithLabels.get(resourceType)) {
       String value = getValue(label, resourceType);
@@ -135,7 +149,46 @@ public class MonitoredResourceUtil {
         builder.addLabel(label.getKey(), value);
       }
     }
-    return builder.build();
+    result = builder.build();
+    cachedMonitoredResources.put(projectId + "/" + resourceType, result);
+    return result;
+  }
+
+  /**
+   * Detect monitored Resource type using the following heuristic rules based on the environment and
+   * metadata server.
+   */
+  private static Resource detectResourceType() {
+    // expects supported Google Cloud resource to have access to metadata server
+    if (MetadataConfig.getAttribute("") == null) {
+      return Resource.Global;
+    }
+
+    if (System.getenv("K_SERVICE") != null
+        && System.getenv("K_REVISION") != null
+        && System.getenv("K_CONFIGURATION") != null) {
+      return Resource.CloudRun;
+    }
+    if (System.getenv("GAE_INSTANCE") != null
+        && System.getenv("GAE_RUNTIME") != null
+        && System.getenv("GAE_SERVICE") != null
+        && System.getenv("GAE_VERSION") != null) {
+      return Resource.AppEngine;
+    }
+    if (System.getenv("FUNCTION_SIGNATURE_TYPE") != null
+        && System.getenv("FUNCTION_TARGET") != null) {
+      return Resource.CloudFunction;
+    }
+    if (MetadataConfig.getAttribute("instance/attributes/cluster-name") != null) {
+      return Resource.K8sContainer;
+    }
+    if (MetadataConfig.getAttribute("instance/preempted") != null
+        && MetadataConfig.getAttribute("instance/cpu-platform") != null
+        && MetadataConfig.getAttribute("instance/attributes/gae_app_bucket") == null) {
+      return Resource.GceInstance;
+    }
+    // other Google Cloud resources (e.g. CloudBuild) might be misdetected
+    return Resource.Global;
   }
 
   /**
@@ -144,135 +197,152 @@ public class MonitoredResourceUtil {
    * @return custom log entry enhancers
    */
   public static List<LoggingEnhancer> getResourceEnhancers() {
-    Resource resourceType = getAutoDetectedResourceType();
+    Resource resourceType = detectResourceType();
     return createEnhancers(resourceType);
   }
 
+  @SuppressWarnings("incomplete-switch")
   private static String getValue(Label label, String resourceType) {
-    String value;
+    String value = "";
+
     switch (label) {
-      case AppId:
-        value = ServiceOptions.getAppEngineAppId();
-        break;
       case ClusterName:
         value = MetadataConfig.getClusterName();
         break;
+      case ConfigurationName:
+        value = System.getenv("K_CONFIGURATION");
+        break;
       case ContainerName:
-        if (resourceType.equals("k8s_container")) {
-          String hostName = System.getenv("HOSTNAME");
-          value = hostName.substring(0, hostName.indexOf("-"));
-        } else {
-          value = MetadataConfig.getContainerName();
+        // there is no determenistic way to discover name of container
+        // allow users to define the container name explicitly
+        value = System.getenv("CONTAINER_NAME");
+        if (value == null) {
+          value = "";
+        }
+        break;
+      case Env:
+        value = getAppEngineEnvironment();
+        break;
+      case FunctionName:
+      case ServiceName:
+        value = System.getenv("K_SERVICE");
+        if (value == null) {
+          value = System.getenv("FUNCTION_NAME");
         }
         break;
       case InstanceId:
         value = MetadataConfig.getInstanceId();
         break;
       case InstanceName:
-        value = getAppEngineInstanceName();
+        value = MetadataConfig.getAttribute("instance/name");
         break;
       case Location:
-        value = getCloudRunLocation();
+        if (Resource.CloudFunction.getKey() == resourceType
+            || Resource.CloudRun.getKey() == resourceType) {
+          value = getRegion();
+        } else {
+          value = getZone();
+        }
         break;
       case ModuleId:
-        value = getAppEngineModuleId();
-        break;
-      case NamespaceId:
-        value = MetadataConfig.getNamespaceId();
+        value = System.getenv("GAE_SERVICE");
         break;
       case NamespaceName:
-        String filePath = System.getenv("KUBERNETES_NAMESPACE_FILE");
-        if (filePath == null) {
-          filePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
-        }
-        try {
-          value = new String(Files.readAllBytes(Paths.get(filePath)), StandardCharsets.UTF_8);
-        } catch (IOException e) {
-          throw new LoggingException(e, true);
-        }
+        value = getK8sNamespace();
         break;
       case PodName:
-      case PodId:
+        // there is no determenistic way to discover name of container
+        // by default the pod name is set as pod's hostname
+        // note that hostname can be overriden in pod manifest or at runtime
         value = System.getenv("HOSTNAME");
+        break;
+      case Region:
+        value = getRegion();
         break;
       case RevisionName:
         value = System.getenv("K_REVISION");
         break;
-      case ServiceName:
-        value = System.getenv("K_SERVICE");
-        break;
       case VersionId:
-        value = getAppEngineVersionId();
+        value = System.getenv("GAE_VERSION");
         break;
       case Zone:
-        value = MetadataConfig.getZone();
+        value = getZone();
         break;
-      default:
-        value = null;
-        break;
+    }
+
+    return value;
+  }
+
+  /**
+   * Heuristic to discover the namespace name of the current environment. There is no determenistic
+   * way to discover the namespace name of the process. The name is read from the {@link
+   * K8S_POD_NAMESPACE_PATH} when available or read from a user defined environment variable
+   * "NAMESPACE_NAME"
+   *
+   * @return Namespace name or empty string if the name could not be discovered
+   */
+  private static String getK8sNamespace() {
+    String value = "";
+    try {
+      value =
+          new String(Files.readAllBytes(Paths.get(K8S_POD_NAMESPACE_PATH)), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      // if SA token is not shared the info about namespace is unavailable
+      // allow users to define the namespace name explicitly
+      value = System.getenv("NAMESPACE_NAME");
+      if (value == null) {
+        value = "";
+      }
     }
     return value;
   }
 
-  /* Detect monitored Resource type using environment variables, else return global as default. */
-  private static Resource getAutoDetectedResourceType() {
-    if (System.getenv("K_SERVICE") != null
-        && System.getenv("K_REVISION") != null
-        && System.getenv("K_CONFIGURATION") != null
-        && System.getenv("KUBERNETES_SERVICE_HOST") == null) {
-      return Resource.CloudRun;
+  /**
+   * Distinguish between Standard and Flexible GAE environments. There is no indicator of the
+   * environment. The path to the startup-script in the metadata attribute was selected as one of
+   * the new values that explitly mentioning "flex" and cannot be altered by user (e.g. environment
+   * variable). The method assumes that the resource type is already identified as {@link
+   * Resource.AppEngine}.
+   *
+   * @return "flex" {@link String} for the Flexible environment and "standard" for the Standard.
+   */
+  private static String getAppEngineEnvironment() {
+    String value = MetadataConfig.getAttribute("instance/attributes/startup-script");
+    if (value == "/var/lib/flex/startup_script.sh") {
+      return FLEX_ENV;
     }
-    if (System.getenv("GAE_INSTANCE") != null) {
-      return Resource.GaeAppFlex;
-    }
-    if (System.getenv("KUBERNETES_SERVICE_HOST") != null) {
-      return Resource.K8sContainer;
-    }
-    if (ServiceOptions.getAppEngineAppId() != null) {
-      return Resource.GaeAppStandard;
-    }
-    if (MetadataConfig.getInstanceId() != null) {
-      return Resource.GceInstance;
-    }
-    // default Resource type
-    return Resource.Global;
+    return STD_ENV;
   }
 
-  private static String getAppEngineModuleId() {
-    return System.getenv("GAE_SERVICE");
+  /**
+   * Retrieves a region from the qualified region of '/projects/[PROJECT_NUMBER]/regions/[REGION]'
+   *
+   * @return region string id
+   */
+  private static String getRegion() {
+    String loc = MetadataConfig.getAttribute("instance/region");
+    return loc.substring(loc.lastIndexOf('/') + 1);
   }
 
-  private static String getAppEngineVersionId() {
-    return System.getenv("GAE_VERSION");
-  }
-
-  private static String getAppEngineInstanceName() {
-    return System.getenv("GAE_INSTANCE");
-  }
-
-  private static String getCloudRunLocation() {
-    String zone = MetadataConfig.getZone();
-    // for Cloud Run managed, the zone is "REGION-1"
-    // So, we need to strip the "-1" to set location to just the region
-    if (zone.endsWith("-1")) return zone.substring(0, zone.length() - 2);
-    else return zone;
+  /**
+   * Retrieves a zone from the qualified zone of '/projects/[PROJECT_NUMBER]/zones/[ZONE]'
+   *
+   * @return zone string id
+   */
+  private static String getZone() {
+    String loc = MetadataConfig.getAttribute("instance/zone");
+    return loc.substring(loc.lastIndexOf('/') + 1);
   }
 
   private static List<LoggingEnhancer> createEnhancers(Resource resourceType) {
     List<LoggingEnhancer> enhancers = new ArrayList<>(2);
-    switch (resourceType) {
-        // Trace logging enhancer is supported on GAE Flex and Standard.
-      case GaeAppFlex:
+    if (resourceType == Resource.AppEngine) {
+      enhancers.add(new TraceLoggingEnhancer(APPENGINE_LABEL_PREFIX));
+      if (getAppEngineEnvironment() == FLEX_ENV) {
         enhancers.add(
             new LabelLoggingEnhancer(
                 APPENGINE_LABEL_PREFIX, Collections.singletonList(Label.InstanceName)));
-        enhancers.add(new TraceLoggingEnhancer(APPENGINE_LABEL_PREFIX));
-        break;
-      case GaeAppStandard:
-        enhancers.add(new TraceLoggingEnhancer(APPENGINE_LABEL_PREFIX));
-        break;
-      default:
-        break;
+      }
     }
     return enhancers;
   }
@@ -282,7 +352,7 @@ public class MonitoredResourceUtil {
    * MonitoredResource.Builder#addLabel(String, String)} are restricted to a supported set per
    * resource.
    *
-   * @see <a href="https://cloud.google.com/logging/docs/api/v2/resource-list">Logging Labels</a>
+   * @see <a href= "https://cloud.google.com/logging/docs/api/v2/resource-list">Logging Labels</a>
    */
   private static class LabelLoggingEnhancer implements LoggingEnhancer {
 

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/ResourceTypeEnvironmentGetter.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/ResourceTypeEnvironmentGetter.java
@@ -45,7 +45,13 @@ final class ResourceTypeEnvironmentGetterImpl implements ResourceTypeEnvironment
 
   @Override
   public String getEnv(String name) {
-    return System.getenv(name);
+    // handle exception thrown if a security manager exists and blocks access to the
+    // process environment
+    try {
+      return System.getenv(name);
+    } catch (SecurityException ex) {
+      return null;
+    }
   }
 
   @Override

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/ResourceTypeEnvironmentGetter.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/ResourceTypeEnvironmentGetter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging;
+
+import com.google.cloud.MetadataConfig;
+
+public interface ResourceTypeEnvironmentGetter {
+
+  /**
+   * Gets the value of the specified environment variable.
+   *
+   * @param name the name of the environment variable
+   * @return the string value of the variable, or <code>null</code> if the variable is not defined
+   *     in the system environment
+   * @see System#getenv()
+   */
+  String getEnv(String name);
+
+  /**
+   * Gets the value of the specified metadata server attribute.
+   *
+   * @param name the name of the metadata server attribute.
+   * @return the string value of the attribute, or <code>null</code> if the attribute is not defined
+   *     in the metadata or the server is not available.
+   * @see MetadataConfig#getAttribute()
+   */
+  String getAttribute(String name);
+}
+
+final class ResourceTypeEnvironmentGetterImpl implements ResourceTypeEnvironmentGetter {
+
+  @Override
+  public String getEnv(String name) {
+    return System.getenv(name);
+  }
+
+  @Override
+  public String getAttribute(String name) {
+    return MetadataConfig.getAttribute(name);
+  }
+}

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/MonitoredResourceUtilTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/MonitoredResourceUtilTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging;
+
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.MonitoredResource;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MonitoredResourceUtilTest {
+  private static final String MOCKED_PROJECT_ID = "mocked-project-id";
+  private static final String MOCKED_ZONE = "mocked-zone-id";
+  private static final String MOCKED_QUALIFIED_ZONE =
+      "projects/" + MOCKED_PROJECT_ID + "/zones/" + MOCKED_ZONE;
+  private static final String MOCKED_REGION = "mocked-region-id";
+  private static final String MOCKED_QUALIFIED_REGION =
+      "projects/" + MOCKED_PROJECT_ID + "/regions/" + MOCKED_REGION;
+  private static final String MOCKED_NON_EMPTY = "project/";
+
+  private ResourceTypeEnvironmentGetter getterMock;
+
+  @Before
+  public void setup() {
+    getterMock = createMock(ResourceTypeEnvironmentGetter.class);
+    expect(getterMock.getAttribute("project/project-id")).andReturn(MOCKED_PROJECT_ID);
+    expect(getterMock.getAttribute("")).andReturn(MOCKED_NON_EMPTY).once();
+    MonitoredResourceUtil.setEnvironmentGetter(getterMock);
+  }
+
+  @After
+  public void teardown() {
+    verify(getterMock);
+  }
+
+  @Test
+  public void testResourceTypeGlobal() {
+    final Map<String, String> ExpectedLabels =
+        ImmutableMap.of("project_id", MonitoredResourceUtilTest.MOCKED_PROJECT_ID);
+
+    // setup
+    expect(getterMock.getAttribute(anyString())).andReturn(null).anyTimes();
+    expect(getterMock.getEnv(anyString())).andReturn(null).anyTimes();
+    replay(getterMock);
+    // exercise
+    MonitoredResource response = MonitoredResourceUtil.getResource("", "");
+    // verify
+    assertEquals(response.getType(), "global");
+    assertTrue(response.getLabels().equals(ExpectedLabels));
+  }
+
+  public void testGetResourceWithParameters() {
+    final String MyProjectId = "my-project-id";
+    final String MyResourceType = "my-resource-type";
+    final Map<String, String> ExpectedLabels = ImmutableMap.of("project_id", MyProjectId);
+
+    // setup
+    replay(getterMock);
+    // exercise
+    MonitoredResource response = MonitoredResourceUtil.getResource(MyProjectId, MyResourceType);
+    // verify
+    assertEquals(response.getType(), "global");
+    assertTrue(response.getLabels().equals(ExpectedLabels));
+  }
+
+  @Test
+  public void testResourceTypeGCEInstance() {
+    final String MockedInstanceId = "1234567890abcdefg";
+    final Map<String, String> ExpectedLabels =
+        ImmutableMap.of(
+            "project_id",
+            MonitoredResourceUtilTest.MOCKED_PROJECT_ID,
+            "instance_id",
+            MockedInstanceId,
+            "zone",
+            MOCKED_ZONE);
+
+    // setup
+    expect(getterMock.getAttribute("instance/id")).andReturn(MockedInstanceId).anyTimes();
+    expect(getterMock.getAttribute("instance/preempted")).andReturn(MOCKED_NON_EMPTY).once();
+    expect(getterMock.getAttribute("instance/cpu-platform")).andReturn(MOCKED_NON_EMPTY).once();
+    expect(getterMock.getAttribute("instance/zone")).andReturn(MOCKED_QUALIFIED_ZONE).once();
+    expect(getterMock.getAttribute(anyString())).andReturn(null).anyTimes();
+    expect(getterMock.getEnv(anyString())).andReturn(null).anyTimes();
+    replay(getterMock);
+    // exercise
+    MonitoredResource response = MonitoredResourceUtil.getResource("", "");
+    // verify
+    assertEquals(response.getType(), "gce_instance");
+    assertTrue(response.getLabels().equals(ExpectedLabels));
+  }
+
+  /**
+   * Attention: This test can be flaky if the path <code>
+   * /var/run/secrets/kubernetes.io/serviceaccount/namespace</code> exists and the file at this path
+   * contains a value other than the mocked constant
+   */
+  @Test
+  public void testResourceTypeK8sContainer() {
+    final String MockedClusterName = "mocked-cluster-1";
+    final String MockedNamespaceName = "default";
+    final String MockedPodName = "mocked-pod";
+    final String MockedContainerName = "mocked-container";
+    final Map<String, String> ExpectedLabels =
+        ImmutableMap.<String, String>builder()
+            .put("project_id", MonitoredResourceUtilTest.MOCKED_PROJECT_ID)
+            .put("cluster_name", MockedClusterName)
+            .put("location", MOCKED_ZONE)
+            .put("namespace_name", MockedNamespaceName)
+            .put("pod_name", MockedPodName)
+            .put("container_name", MockedContainerName)
+            .build();
+
+    // setup
+    expect(getterMock.getAttribute("instance/attributes/cluster-name"))
+        .andReturn(MockedClusterName)
+        .times(2);
+    expect(getterMock.getAttribute("instance/zone")).andReturn(MOCKED_QUALIFIED_ZONE).once();
+    expect(getterMock.getAttribute(anyString())).andReturn(null).anyTimes();
+    expect(getterMock.getEnv("HOSTNAME")).andReturn(MockedPodName).anyTimes();
+    expect(getterMock.getEnv("NAMESPACE_NAME")).andReturn(MockedNamespaceName).anyTimes();
+    expect(getterMock.getEnv("CONTAINER_NAME")).andReturn(MockedContainerName).anyTimes();
+    expect(getterMock.getEnv(anyString())).andReturn(null).anyTimes();
+    replay(getterMock);
+    // exercise
+    MonitoredResource response = MonitoredResourceUtil.getResource("", "");
+    // verify
+    assertEquals(response.getType(), "k8s_container");
+    assertTrue(response.getLabels().equals(ExpectedLabels));
+  }
+
+  private void setupCommonGAEMocks(String mockedModuleId, String mockedVersionId) {
+    expect(getterMock.getAttribute("instance/zone")).andReturn(MOCKED_QUALIFIED_ZONE).once();
+    expect(getterMock.getEnv("GAE_INSTANCE")).andReturn(MOCKED_NON_EMPTY).once();
+    expect(getterMock.getEnv("GAE_RUNTIME")).andReturn(MOCKED_NON_EMPTY).once();
+    expect(getterMock.getEnv("GAE_SERVICE")).andReturn(mockedModuleId).times(2);
+    expect(getterMock.getEnv("GAE_VERSION")).andReturn(mockedVersionId).times(2);
+    expect(getterMock.getEnv(anyString())).andReturn(null).anyTimes();
+  }
+
+  @Test
+  public void testResourceTypeGAEStandardEnvironment() {
+    final String MockedModuleId = "mocked-module-id";
+    final String MockedVersionId = "mocked-version-id";
+    final Map<String, String> ExpectedLabels =
+        ImmutableMap.of(
+            "project_id",
+            MonitoredResourceUtilTest.MOCKED_PROJECT_ID,
+            "module_id",
+            MockedModuleId,
+            "version_id",
+            MockedVersionId,
+            "env",
+            "standard",
+            "zone",
+            MOCKED_ZONE);
+
+    // setup
+    setupCommonGAEMocks(MockedModuleId, MockedVersionId);
+    expect(getterMock.getAttribute(anyString())).andReturn(null).anyTimes();
+    replay(getterMock);
+    // exercise
+    MonitoredResource response = MonitoredResourceUtil.getResource("", "");
+    // verify
+    assertEquals(response.getType(), "gae_app");
+    assertTrue(response.getLabels().equals(ExpectedLabels));
+  }
+
+  @Test
+  public void testResourceTypeGAEFlexibleEnvironment() {
+    final String MockedModuleId = "mocked-module-id";
+    final String MockedVersionId = "mocked-version-id";
+    final Map<String, String> ExpectedLabels =
+        ImmutableMap.of(
+            "project_id",
+            MonitoredResourceUtilTest.MOCKED_PROJECT_ID,
+            "module_id",
+            MockedModuleId,
+            "version_id",
+            MockedVersionId,
+            "env",
+            "flex",
+            "zone",
+            MOCKED_ZONE);
+
+    // setup
+    setupCommonGAEMocks(MockedModuleId, MockedVersionId);
+    expect(getterMock.getAttribute("instance/attributes/startup-script"))
+        .andReturn("/var/lib/flex/startup_script.sh")
+        .once();
+    replay(getterMock);
+    // exercise
+    MonitoredResource response = MonitoredResourceUtil.getResource("", "");
+    // verify
+    assertEquals(response.getType(), "gae_app");
+    assertTrue(response.getLabels().equals(ExpectedLabels));
+  }
+
+  @Test
+  public void testResourceTypeCloudFunction() {
+    final String MockedFunctionName = "mocked-function-name";
+    final Map<String, String> ExpectedLabels =
+        ImmutableMap.of(
+            "project_id",
+            MonitoredResourceUtilTest.MOCKED_PROJECT_ID,
+            "function_name",
+            MockedFunctionName,
+            "region",
+            MOCKED_REGION);
+
+    // setup
+    expect(getterMock.getAttribute("instance/region")).andReturn(MOCKED_QUALIFIED_REGION).once();
+    expect(getterMock.getAttribute(anyString())).andReturn(null).anyTimes();
+    expect(getterMock.getEnv("FUNCTION_SIGNATURE_TYPE")).andReturn(MOCKED_NON_EMPTY).once();
+    expect(getterMock.getEnv("FUNCTION_TARGET")).andReturn(MOCKED_NON_EMPTY).once();
+    expect(getterMock.getEnv("K_SERVICE")).andReturn(MockedFunctionName).anyTimes();
+    expect(getterMock.getEnv(anyString())).andReturn(null).anyTimes();
+    replay(getterMock);
+    // exercise
+    MonitoredResource response = MonitoredResourceUtil.getResource("", "");
+    // verify
+    assertEquals(response.getType(), "cloud_function");
+    assertTrue(response.getLabels().equals(ExpectedLabels));
+  }
+
+  @Test
+  public void testResourceTypeCloudRun() {
+    final String MockedRevisionName = "mocked-revision-name";
+    final String MockedServiceName = "mocked-service-name";
+    final String MockedConfigurationName = "mocked-config-name";
+    final Map<String, String> ExpectedLabels =
+        ImmutableMap.of(
+            "project_id",
+            MonitoredResourceUtilTest.MOCKED_PROJECT_ID,
+            "revision_name",
+            MockedRevisionName,
+            "configuration_name",
+            MockedConfigurationName,
+            "service_name",
+            MockedServiceName,
+            "location",
+            MOCKED_REGION);
+
+    // setup
+    expect(getterMock.getAttribute("instance/region")).andReturn(MOCKED_QUALIFIED_REGION).once();
+    expect(getterMock.getAttribute(anyString())).andReturn(null).anyTimes();
+    expect(getterMock.getEnv("K_CONFIGURATION")).andReturn(MockedConfigurationName).times(2);
+    expect(getterMock.getEnv("K_REVISION")).andReturn(MockedRevisionName).times(2);
+    expect(getterMock.getEnv("K_SERVICE")).andReturn(MockedServiceName).anyTimes();
+    expect(getterMock.getEnv(anyString())).andReturn(null).anyTimes();
+    replay(getterMock);
+    // exercise
+    MonitoredResource response = MonitoredResourceUtil.getResource("", "");
+    // verify
+    assertEquals(response.getType(), "cloud_run_revision");
+    assertTrue(response.getLabels().equals(ExpectedLabels));
+  }
+}


### PR DESCRIPTION
Implement more robust resource type discovery including support for Cloud Function resource. Cache results per pair of the project id and resource type.
Refactor [MonitoredResourceUtil.java ](https://github.com/googleapis/java-logging/blob/main/google-cloud-logging/src/main/java/com/google/cloud/logging/MonitoredResourceUtil.java) to allow mocking static methods that read environment variables and metadata server attributes by using `ResourceTypeEnvironmentGetter` class.
Implement unit testing of the `MonitoredResourceUtil.getResource()` for each detected environment.

Fixes #685
