### PR TITLE
fix: modify list log entries example documentation

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -94,7 +94,7 @@ custom_content: |
   imports at the top of your file:
   
   ```java
-  import com.google.cloud.Page;
+  import com.google.api.gax.paging.Page;
   import com.google.cloud.logging.LogEntry;
   import com.google.cloud.logging.Logging.EntryListOption;
   ```
@@ -102,14 +102,14 @@ custom_content: |
   Then, to list the log entries, use the following code:
 
   ``` java
-  Page<LogEntry> entries = logging.listLogEntries(
-      EntryListOption.filter("logName=projects/" + options.getProjectId() + "/logs/test-log"));
-  Iterator<LogEntry> entryIterator = entries.iterateAll().iterator();
-  while (entryIterator.hasNext()) {
-    System.out.println(entryIterator.next());
+  Page<LogEntry> entries = logging.listLogEntries(EntryListOption.filter(logFilter));
+  while (entries != null) {
+    for (LogEntry logEntry : entries.iterateAll()) {
+      System.out.println(logEntry);
+    }
+    entries = entries.getNextPage();
   }
   ```
-
   #### Add a Cloud Logging handler to a logger
   
   You can also register a `LoggingHandler` to a `java.util.logging.Logger` that publishes log entries
@@ -133,13 +133,3 @@ custom_content: |
   ```
   com.google.cloud.examples.logging.snippets.AddLoggingHandler.handlers=com.google.cloud.logging.LoggingHandler
   ```
-  
-  #### Complete source code
-
-  In
-  [CreateAndListMetrics.java](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/logging/snippets/CreateAndListMetrics.java),
-  [WriteAndListLogEntries.java](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/logging/snippets/WriteAndListLogEntries.java)
-  and
-  [AddLoggingHandler.java](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/logging/snippets/AddLoggingHandler.java)
-  we put together all the code shown above into three programs. The programs assume that you are
-  running on Compute Engine or from your own desktop.

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -102,7 +102,8 @@ custom_content: |
   Then, to list the log entries, use the following code:
 
   ``` java
-  Page<LogEntry> entries = logging.listLogEntries(EntryListOption.filter(logFilter));
+  Page<LogEntry> entries = logging.listLogEntries(
+      EntryListOption.filter("logName=projects/" + options.getProjectId() + "/logs/test-log"));
   while (entries != null) {
     for (LogEntry logEntry : entries.iterateAll()) {
       System.out.println(logEntry);

--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ import com.google.cloud.logging.Logging.EntryListOption;
 Then, to list the log entries, use the following code:
 
 ``` java
-Page<LogEntry> entries = logging.listLogEntries(EntryListOption.filter(logFilter));
+Page<LogEntry> entries = logging.listLogEntries(
+    EntryListOption.filter("logName=projects/" + options.getProjectId() + "/logs/test-log"));
 while (entries != null) {
   for (LogEntry logEntry : entries.iterateAll()) {
     System.out.println(logEntry);

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ With Logging you can also list log entries that have been previously written. Ad
 imports at the top of your file:
 
 ```java
-import com.google.cloud.Page;
+import com.google.api.gax.paging.Page;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging.EntryListOption;
 ```
@@ -202,14 +202,14 @@ import com.google.cloud.logging.Logging.EntryListOption;
 Then, to list the log entries, use the following code:
 
 ``` java
-Page<LogEntry> entries = logging.listLogEntries(
-    EntryListOption.filter("logName=projects/" + options.getProjectId() + "/logs/test-log"));
-Iterator<LogEntry> entryIterator = entries.iterateAll().iterator();
-while (entryIterator.hasNext()) {
-  System.out.println(entryIterator.next());
+Page<LogEntry> entries = logging.listLogEntries(EntryListOption.filter(logFilter));
+while (entries != null) {
+  for (LogEntry logEntry : entries.iterateAll()) {
+    System.out.println(logEntry);
+  }
+  entries = entries.getNextPage();
 }
 ```
-
 #### Add a Cloud Logging handler to a logger
 
 You can also register a `LoggingHandler` to a `java.util.logging.Logger` that publishes log entries
@@ -234,15 +234,6 @@ file. Adding, for instance, the following line:
 com.google.cloud.examples.logging.snippets.AddLoggingHandler.handlers=com.google.cloud.logging.LoggingHandler
 ```
 
-#### Complete source code
-
-In
-[CreateAndListMetrics.java](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/logging/snippets/CreateAndListMetrics.java),
-[WriteAndListLogEntries.java](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/logging/snippets/WriteAndListLogEntries.java)
-and
-[AddLoggingHandler.java](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/logging/snippets/AddLoggingHandler.java)
-we put together all the code shown above into three programs. The programs assume that you are
-running on Compute Engine or from your own desktop.
 
 
 


### PR DESCRIPTION
provide the working example to list log entries including going through multiple pages.
remove the reference to the unmaintained code samples in the [google-cloud-java](https://github.com/googleapis/google-cloud-java) repository

Fixes #648
