### PR TITLE
fix: restore batching for writeLogEntriesCallable

### DIFF
--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2Stub.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2Stub.java
@@ -239,7 +239,7 @@ public class GrpcLoggingServiceV2Stub extends LoggingServiceV2Stub {
         callableFactory.createUnaryCallable(
             deleteLogTransportSettings, settings.deleteLogSettings(), clientContext);
     this.writeLogEntriesCallable =
-        callableFactory.createUnaryCallable(
+        callableFactory.createBatchingCallable(
             writeLogEntriesTransportSettings, settings.writeLogEntriesSettings(), clientContext);
     this.listLogEntriesCallable =
         callableFactory.createUnaryCallable(


### PR DESCRIPTION
handles regression in gapic-generator-java which setup the `writeLogEntriesCallable` stub
to be created using `createUnaryCallable` instead of `createBatchingCallable`.
Update the environment test sub-module to point to the latest commit.

Fixes #744
