### PR TITLE
fix: handle null pointer when parsing metadata attributes

### DIFF
--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/MetadataLoader.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/MetadataLoader.java
@@ -87,8 +87,8 @@ public final class MetadataLoader {
    * Distinguish between Standard and Flexible GAE environments. There is no indicator of the
    * environment. The path to the startup-script in the metadata attribute was selected as one of
    * the new values that explitly mentioning "flex" and cannot be altered by user (e.g. environment
-   * variable). The method assumes that the resource type is already identified as {@link
-   * Resource.AppEngine}.
+   * variable).
+   * The method assumes that the resource type is already identified as {@link Resource.AppEngine}.
    *
    * @return {@link MetadataLoader.ENV_FLEXIBLE} for the Flexible environment and {@link
    *     MetadataLoader.ENV_STANDARD} for the Standard environment.
@@ -137,10 +137,10 @@ public final class MetadataLoader {
    * K8S_POD_NAMESPACE_PATH} when available or read from a user defined environment variable
    * "NAMESPACE_NAME"
    *
-   * @return Namespace name or empty string if the name could not be discovered
+   * @return Namespace string or null if the name could not be discovered
    */
   private String getNamespaceName() {
-    String value = "";
+    String value = null;
     try {
       value =
           new String(
@@ -151,9 +151,6 @@ public final class MetadataLoader {
       // if SA token is not shared the info about namespace is unavailable
       // allow users to define the namespace name explicitly
       value = getter.getEnv("NAMESPACE_NAME");
-      if (value == null) {
-        value = "";
-      }
     }
     return value;
   }
@@ -178,7 +175,10 @@ public final class MetadataLoader {
    */
   private String getRegion() {
     String loc = getter.getAttribute("instance/region");
-    return loc.substring(loc.lastIndexOf('/') + 1);
+    if (loc != null) {
+      return loc.substring(loc.lastIndexOf('/') + 1);
+    }
+    return null;
   }
 
   private String getRevisionName() {
@@ -199,6 +199,9 @@ public final class MetadataLoader {
    */
   private String getZone() {
     String loc = getter.getAttribute("instance/zone");
-    return loc.substring(loc.lastIndexOf('/') + 1);
+    if (loc != null) {
+      return loc.substring(loc.lastIndexOf('/') + 1);
+    }
+    return null;
   }
 }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/MetadataLoader.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/MetadataLoader.java
@@ -87,8 +87,8 @@ public final class MetadataLoader {
    * Distinguish between Standard and Flexible GAE environments. There is no indicator of the
    * environment. The path to the startup-script in the metadata attribute was selected as one of
    * the new values that explitly mentioning "flex" and cannot be altered by user (e.g. environment
-   * variable).
-   * The method assumes that the resource type is already identified as {@link Resource.AppEngine}.
+   * variable). The method assumes that the resource type is already identified as {@link
+   * Resource.AppEngine}.
    *
    * @return {@link MetadataLoader.ENV_FLEXIBLE} for the Flexible environment and {@link
    *     MetadataLoader.ENV_STANDARD} for the Standard environment.


### PR DESCRIPTION
Fix behavior of getRegion and getZone methods when attributes aren't defined.
Align getNamespaceName return value with other methods to return null.

Addresses googleapis/java-logging-logback#599 when incorrect resource type is enforced.