### PR TITLE
chore(clirr): customize clirr behavior for java7 branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,79 +1,87 @@
-on:
+'on':
   push:
     branches:
-    - master
-  pull_request:
+      - java7
+  pull_request: null
 name: ci
 jobs:
   units:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [7, 8, 11]
+        java:
+          - 7
+          - 8
+          - 11
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
-      with:
-        java-version: ${{matrix.java}}
-    - run: java -version
-    - run: .kokoro/build.sh
-      env:
-        JOB_TYPE: test
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: ${{matrix.java}}
+      - run: java -version
+      - run: .kokoro/build.sh
+        env:
+          JOB_TYPE: test
   windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - run: java -version
-    - run: .kokoro/build.bat
-      env:
-        JOB_TYPE: test
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - run: java -version
+      - run: .kokoro/build.bat
+        env:
+          JOB_TYPE: test
   dependencies:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11]
+        java:
+          - 8
+          - 11
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
-      with:
-        java-version: ${{matrix.java}}
-    - run: java -version
-    - run: .kokoro/dependencies.sh
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: ${{matrix.java}}
+      - run: java -version
+      - run: .kokoro/dependencies.sh
   linkage-monitor:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - run: java -version
-    - name: Install artifacts to local Maven repository
-      run: .kokoro/build.sh
-      shell: bash
-    - name: Validate any conflicts with regard to com.google.cloud:libraries-bom (latest release)
-      uses: GoogleCloudPlatform/cloud-opensource-java/linkage-monitor@v1-linkagemonitor
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - run: java -version
+      - name: Install artifacts to local Maven repository
+        run: .kokoro/build.sh
+        shell: bash
+      - name: >-
+          Validate any conflicts with regard to com.google.cloud:libraries-bom
+          (latest release)
+        uses: >-
+          GoogleCloudPlatform/cloud-opensource-java/linkage-monitor@v1-linkagemonitor
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - run: java -version
-    - run: .kokoro/build.sh
-      env:
-        JOB_TYPE: lint
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - run: java -version
+      - run: .kokoro/build.sh
+        env:
+          JOB_TYPE: lint
   clirr:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - run: java -version
-    - run: .kokoro/build.sh
-      env:
-        JOB_TYPE: clirr
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - run: java -version
+      - run: .kokoro/build.sh
+        env:
+          JOB_TYPE: clirr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.4.0](https://www.github.com/googleapis/java-logging/compare/v2.3.2...v2.4.0) (2021-11-22)
+
+
+### Features
+
+* configure initial sp version ([#604](https://www.github.com/googleapis/java-logging/issues/604)) ([0b8e707](https://www.github.com/googleapis/java-logging/commit/0b8e707cb007f572a27804e15237a6e584b20b5a))
+
+
+### Bug Fixes
+
+* restore batching for writeLogEntriesCallable ([#754](https://www.github.com/googleapis/java-logging/issues/754)) ([9b92d0a](https://www.github.com/googleapis/java-logging/commit/9b92d0a3d0bc51567c49cf916c4cb8063ae9a33f)), closes [#744](https://www.github.com/googleapis/java-logging/issues/744)
+
 ### [2.3.2](https://www.github.com/googleapis/java-logging/compare/v2.3.1...v2.3.2) (2021-07-01)
 
 

--- a/google-cloud-logging-bom/pom.xml
+++ b/google-cloud-logging-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging-bom</artifactId>
-  <version>2.3.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+  <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
   <packaging>pom</packaging>
   <parent>
     <groupId>com.google.cloud</groupId>
@@ -64,17 +64,17 @@
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-logging-v2</artifactId>
-        <version>0.88.2</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
+        <version>0.88.3-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-logging-v2</artifactId>
-        <version>0.88.2</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
+        <version>0.88.3-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-logging</artifactId>
-        <version>2.3.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+        <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-cloud-logging-bom/pom.xml
+++ b/google-cloud-logging-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging-bom</artifactId>
-  <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+  <version>2.4.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   <packaging>pom</packaging>
   <parent>
     <groupId>com.google.cloud</groupId>
@@ -64,17 +64,17 @@
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-logging-v2</artifactId>
-        <version>0.88.3-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
+        <version>0.89.0</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-logging-v2</artifactId>
-        <version>0.88.3-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
+        <version>0.89.0</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-logging</artifactId>
-        <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+        <version>2.4.0</version><!-- {x-version-update:google-cloud-logging:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-cloud-logging/pom.xml
+++ b/google-cloud-logging/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging</artifactId>
-  <version>2.3.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+  <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Logging</name>
   <url>https://github.com/googleapis/java-logging</url>
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-logging-parent</artifactId>
-    <version>2.3.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+    <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
   </parent>
   <properties>
     <site.installationModule>google-cloud-logging</site.installationModule>

--- a/google-cloud-logging/pom.xml
+++ b/google-cloud-logging/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging</artifactId>
-  <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+  <version>2.4.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Logging</name>
   <url>https://github.com/googleapis/java-logging</url>
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-logging-parent</artifactId>
-    <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+    <version>2.4.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   </parent>
   <properties>
     <site.installationModule>google-cloud-logging</site.installationModule>

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2Stub.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2Stub.java
@@ -239,7 +239,7 @@ public class GrpcLoggingServiceV2Stub extends LoggingServiceV2Stub {
         callableFactory.createUnaryCallable(
             deleteLogTransportSettings, settings.deleteLogSettings(), clientContext);
     this.writeLogEntriesCallable =
-        callableFactory.createUnaryCallable(
+        callableFactory.createBatchingCallable(
             writeLogEntriesTransportSettings, settings.writeLogEntriesSettings(), clientContext);
     this.listLogEntriesCallable =
         callableFactory.createUnaryCallable(

--- a/grpc-google-cloud-logging-v2/pom.xml
+++ b/grpc-google-cloud-logging-v2/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>grpc-google-cloud-logging-v2</artifactId>
-  <version>0.88.2</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
+  <version>0.88.3-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
   <name>grpc-google-cloud-logging-v2</name>
   <description>GRPC library for grpc-google-cloud-logging-v2</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-logging-parent</artifactId>
-    <version>2.3.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+    <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/grpc-google-cloud-logging-v2/pom.xml
+++ b/grpc-google-cloud-logging-v2/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>grpc-google-cloud-logging-v2</artifactId>
-  <version>0.88.3-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
+  <version>0.89.0</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
   <name>grpc-google-cloud-logging-v2</name>
   <description>GRPC library for grpc-google-cloud-logging-v2</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-logging-parent</artifactId>
-    <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+    <version>2.4.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.3.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+  <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
   <name>Google Cloud Logging Parent</name>
   <url>https://github.com/googleapis/java-logging</url>
   <description>
@@ -70,17 +70,17 @@
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-logging-v2</artifactId>
-        <version>0.88.2</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
+        <version>0.88.3-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-logging-v2</artifactId>
-        <version>0.88.2</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
+        <version>0.88.3-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-logging</artifactId>
-        <version>2.3.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+        <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,15 @@
             <ignoredUnusedDeclaredDependencies>org.objenesis:objenesis</ignoredUnusedDeclaredDependencies>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>clirr-maven-plugin</artifactId>
+          <version>2.8</version>
+          <configuration>
+            <!-- Compare the current code against version 2.3.0 instead of latest 3.x -->
+            <comparisonVersion>2.3.0</comparisonVersion>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-logging-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+  <version>2.4.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   <name>Google Cloud Logging Parent</name>
   <url>https://github.com/googleapis/java-logging</url>
   <description>
@@ -70,17 +70,17 @@
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-logging-v2</artifactId>
-        <version>0.88.3-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
+        <version>0.89.0</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-logging-v2</artifactId>
-        <version>0.88.3-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
+        <version>0.89.0</version><!-- {x-version-update:grpc-google-cloud-logging-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-logging</artifactId>
-        <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+        <version>2.4.0</version><!-- {x-version-update:google-cloud-logging:current} -->
       </dependency>
 
       <dependency>

--- a/proto-google-cloud-logging-v2/pom.xml
+++ b/proto-google-cloud-logging-v2/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>proto-google-cloud-logging-v2</artifactId>
-  <version>0.88.2</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
+  <version>0.88.3-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
   <name>proto-google-cloud-logging-v2</name>
   <description>PROTO library for proto-google-cloud-logging-v2</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-logging-parent</artifactId>
-    <version>2.3.2</version><!-- {x-version-update:google-cloud-logging:current} -->
+    <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/proto-google-cloud-logging-v2/pom.xml
+++ b/proto-google-cloud-logging-v2/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>proto-google-cloud-logging-v2</artifactId>
-  <version>0.88.3-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
+  <version>0.89.0</version><!-- {x-version-update:proto-google-cloud-logging-v2:current} -->
   <name>proto-google-cloud-logging-v2</name>
   <description>PROTO library for proto-google-cloud-logging-v2</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-logging-parent</artifactId>
-    <version>2.3.3-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+    <version>2.4.0</version><!-- {x-version-update:google-cloud-logging:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-logging</artifactId>
-      <version>2.3.2</version>
+      <version>2.3.3-SNAPSHOT</version>
     </dependency>
     <!-- {x-version-update-end} -->
     <dependency>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-logging</artifactId>
-      <version>2.3.3-SNAPSHOT</version>
+      <version>2.4.0</version>
     </dependency>
     <!-- {x-version-update-end} -->
     <dependency>

--- a/versions.txt
+++ b/versions.txt
@@ -1,6 +1,6 @@
 # Format:
 # module:released-version:current-version
 
-proto-google-cloud-logging-v2:0.88.2:0.88.2
-grpc-google-cloud-logging-v2:0.88.2:0.88.2
-google-cloud-logging:2.3.2:2.3.2
+proto-google-cloud-logging-v2:0.88.2:0.88.3-SNAPSHOT
+grpc-google-cloud-logging-v2:0.88.2:0.88.3-SNAPSHOT
+google-cloud-logging:2.3.2:2.3.3-SNAPSHOT

--- a/versions.txt
+++ b/versions.txt
@@ -1,6 +1,6 @@
 # Format:
 # module:released-version:current-version
 
-proto-google-cloud-logging-v2:0.88.2:0.88.3-SNAPSHOT
-grpc-google-cloud-logging-v2:0.88.2:0.88.3-SNAPSHOT
-google-cloud-logging:2.3.2:2.3.3-SNAPSHOT
+proto-google-cloud-logging-v2:0.89.0:0.89.0
+grpc-google-cloud-logging-v2:0.89.0:0.89.0
+google-cloud-logging:2.4.0:2.4.0


### PR DESCRIPTION
by default clirr plugin compares vs. latest (for maven) release of the package which is (for logging) 3.x.
java7 branch builds 2.x versions (current 2.4.0). this change customizes clirr configuration for logging
to make clirr to compare vs. previous release (2.3.0). there is no way to automate this process i.e. update 2.3.0 to 2.4.0 when java7 branch rolls to next minor version. this change will have to be done manually.