### PR TITLE
chore(java7,clirr): make clirr to compare vs 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,30 +138,12 @@
           <artifactId>clirr-maven-plugin</artifactId>
           <version>2.8</version>
           <configuration>
-            <!-- Compare the current code against version 2.3.0 -->
+            <!-- Compare the current code against version 2.3.0 instead of latest 3.x -->
             <comparisonVersion>2.3.0</comparisonVersion>
           </configuration>
         </plugin>
       </plugins>
     </pluginManagement>
-    <!-- <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>clirr-maven-plugin</artifactId>
-        <configuration>
-          <comparisonVersion>2.3.0</comparisonVersion>
-          <ignoredDifferencesFile>clirr-ignored-differences.xml</ignoredDifferencesFile>
-          <logResults>true</logResults>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins> -->
   </build>
 
   <modules>


### PR DESCRIPTION
by default clirr plugin compares vs. latest (for maven) release of the package which is (for logging) 3.x.
java7 branch builds 2.x versions (current 2.4.0). this change customizes clirr configuration for logging
to make clirr to compare vs. previous release (2.3.0). there is no way to automate this process i.e. update 2.3.0 to 2.4.0 when java7 branch rolls to next minor version. this change will have to be done manually.