### PR TITLE
fix: remove distributionManagement from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,16 +41,6 @@
     <url>https://github.com/googleapis/java-logging/issues</url>
     <system>GitHub Issues</system>
   </issueManagement>
-  <distributionManagement>
-    <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>sonatype-nexus-staging</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
   <licenses>
     <license>
       <name>Apache-2.0</name>


### PR DESCRIPTION
Fix the problem with a release process by removing "local" <distributionManagement> to enforce the use of one in the shared configuration.

Fixes #762
