### PR TITLE
fix: fix: Rename staleness.critical config parameter to staleness.extraold

### DIFF
--- a/.github/auto-label.yaml
+++ b/.github/auto-label.yaml
@@ -2,4 +2,4 @@ product: true
 staleness:
   pullrequest: true
   old: 30
-  critical: 60
+  extraold: 60


### PR DESCRIPTION
fix: Rename staleness.critical config parameter to staleness.extraold in .github/auto-label.yaml
