### PR TITLE
fix: Expose ID and destination type of LogDestinationName publicly

### DIFF
--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LogDestinationName.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LogDestinationName.java
@@ -29,7 +29,7 @@ import java.util.Map;
 public final class LogDestinationName extends Option {
   private static final long serialVersionUID = 7944256748441111191L;
 
-  enum DestinationType implements Option.OptionType {
+  public enum DestinationType implements Option.OptionType {
     PROJECT,
     FOLDER,
     ORGANIZATION,
@@ -107,6 +107,16 @@ public final class LogDestinationName extends Option {
     }
 
     return null;
+  }
+
+  /** Returns ID value associated with {@code LogDestinationName} object */
+  public String getId() {
+    return getValue().toString();
+  }
+
+  /** Returns destination type option value associated with {@code LogDestinationName} object */
+  public DestinationType getDestinationType() {
+    return getOptionType();
   }
 
   /** Creates a {@code LogDestinationName} object from given {@code LogName}. */

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingTest.java
@@ -116,25 +116,25 @@ public class LoggingTest {
     WriteOption writeOption = WriteOption.destination(LogDestinationName.project(PROJECT_NAME));
     LogDestinationName resource = (LogDestinationName) writeOption.getValue();
     assertEquals(WriteOption.OptionType.LOG_DESTINATION, writeOption.getOptionType());
-    assertEquals(LogDestinationName.DestinationType.PROJECT, resource.getOptionType());
-    assertEquals(PROJECT_NAME, resource.getValue());
+    assertEquals(LogDestinationName.DestinationType.PROJECT, resource.getDestinationType());
+    assertEquals(PROJECT_NAME, resource.getId());
 
     writeOption = WriteOption.destination(LogDestinationName.billingAccount(BILLING_NAME));
     resource = (LogDestinationName) writeOption.getValue();
     assertEquals(WriteOption.OptionType.LOG_DESTINATION, writeOption.getOptionType());
-    assertEquals(LogDestinationName.DestinationType.BILLINGACCOUNT, resource.getOptionType());
-    assertEquals(BILLING_NAME, resource.getValue());
+    assertEquals(LogDestinationName.DestinationType.BILLINGACCOUNT, resource.getDestinationType());
+    assertEquals(BILLING_NAME, resource.getId());
 
     writeOption = WriteOption.destination(LogDestinationName.folder(FOLDER_NAME));
     resource = (LogDestinationName) writeOption.getValue();
     assertEquals(WriteOption.OptionType.LOG_DESTINATION, writeOption.getOptionType());
-    assertEquals(LogDestinationName.DestinationType.FOLDER, resource.getOptionType());
-    assertEquals(FOLDER_NAME, resource.getValue());
+    assertEquals(LogDestinationName.DestinationType.FOLDER, resource.getDestinationType());
+    assertEquals(FOLDER_NAME, resource.getId());
 
     writeOption = WriteOption.destination(LogDestinationName.organization(ORGANIZATION_NAME));
     resource = (LogDestinationName) writeOption.getValue();
     assertEquals(WriteOption.OptionType.LOG_DESTINATION, writeOption.getOptionType());
-    assertEquals(LogDestinationName.DestinationType.ORGANIZATION, resource.getOptionType());
-    assertEquals(ORGANIZATION_NAME, resource.getValue());
+    assertEquals(LogDestinationName.DestinationType.ORGANIZATION, resource.getDestinationType());
+    assertEquals(ORGANIZATION_NAME, resource.getId());
   }
 }


### PR DESCRIPTION
Expose ID and destination type of LogDestinationName publicly
This is additional fix for [#684](https://github.com/googleapis/java-logging/issues/684) ☕️
