### PR TITLE
feat: allow opt-out auto-population of the log entry metadata on write()

### DIFF
--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
@@ -70,7 +70,8 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
       LOG_NAME,
       RESOURCE,
       LABELS,
-      LOG_DESTINATION;
+      LOG_DESTINATION,
+      AUTO_POPULATE_METADATA;
 
       @SuppressWarnings("unchecked")
       <T> T get(Map<Option.OptionType, ?> options) {
@@ -113,6 +114,14 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
      */
     public static WriteOption destination(LogDestinationName destination) {
       return new WriteOption(OptionType.LOG_DESTINATION, destination);
+    }
+
+    /**
+     * Returns an option to opt-out automatic population of log entries metadata fields that are not
+     * set.
+     */
+    public static WriteOption autoPopulateMetadata(boolean autoPopulateMetadata) {
+      return new WriteOption(OptionType.AUTO_POPULATE_METADATA, autoPopulateMetadata);
     }
   }
 

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingConfig.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingConfig.java
@@ -88,10 +88,11 @@ class LoggingConfig {
       if (list != null) {
         String[] items = list.split(",");
         for (String e_name : items) {
-          Class<? extends LoggingEnhancer> clz =
-              (Class<? extends LoggingEnhancer>)
-                  ClassLoader.getSystemClassLoader().loadClass(e_name);
-          enhancers.add(clz.getDeclaredConstructor().newInstance());
+          Class<? extends LoggingEnhancer> clazz =
+              ClassLoader.getSystemClassLoader()
+                  .loadClass(e_name)
+                  .asSubclass(LoggingEnhancer.class);
+          enhancers.add(clazz.getDeclaredConstructor().newInstance());
         }
       }
       return enhancers;

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingOptions.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingOptions.java
@@ -38,6 +38,8 @@ public class LoggingOptions extends ServiceOptions<Logging, LoggingOptions> {
   private static final String DEFAULT_HOST = LoggingSettings.getDefaultEndpoint();
   private static final long serialVersionUID = 5753499510627426717L;
 
+  private Boolean autoPopulateMetadataOnWrite = null;
+
   public static class DefaultLoggingFactory implements LoggingFactory {
     private static final LoggingFactory INSTANCE = new DefaultLoggingFactory();
 
@@ -72,6 +74,8 @@ public class LoggingOptions extends ServiceOptions<Logging, LoggingOptions> {
 
   public static class Builder extends ServiceOptions.Builder<Logging, LoggingOptions, Builder> {
 
+    private Boolean autoPopulateMetadataOnWrite = true;
+
     private Builder() {}
 
     private Builder(LoggingOptions options) {
@@ -87,6 +91,11 @@ public class LoggingOptions extends ServiceOptions<Logging, LoggingOptions> {
       return super.setTransportOptions(transportOptions);
     }
 
+    public Builder setAutoPopulateMetadata(boolean autoPopulateMetadataOnWrite) {
+      this.autoPopulateMetadataOnWrite = autoPopulateMetadataOnWrite;
+      return this;
+    }
+
     @Override
     public LoggingOptions build() {
       return new LoggingOptions(this);
@@ -96,6 +105,7 @@ public class LoggingOptions extends ServiceOptions<Logging, LoggingOptions> {
   @InternalApi("This class should only be extended within google-cloud-java")
   protected LoggingOptions(Builder builder) {
     super(LoggingFactory.class, LoggingRpcFactory.class, builder, new LoggingDefaults());
+    this.autoPopulateMetadataOnWrite = builder.autoPopulateMetadataOnWrite;
   }
 
   @SuppressWarnings("serial")
@@ -128,6 +138,10 @@ public class LoggingOptions extends ServiceOptions<Logging, LoggingOptions> {
 
   protected LoggingRpc getLoggingRpcV2() {
     return (LoggingRpc) getRpc();
+  }
+
+  public Boolean getAutoPopulate() {
+    return this.autoPopulateMetadataOnWrite;
   }
 
   @Override

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingOptions.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingOptions.java
@@ -140,7 +140,7 @@ public class LoggingOptions extends ServiceOptions<Logging, LoggingOptions> {
     return (LoggingRpc) getRpc();
   }
 
-  public Boolean getAutoPopulate() {
+  public Boolean getAutoPopulateMetadata() {
     return this.autoPopulateMetadataOnWrite;
   }
 

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingOptionsTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingOptionsTest.java
@@ -16,21 +16,31 @@
 
 package com.google.cloud.logging;
 
+import static org.easymock.EasyMock.createMock;
+import static org.junit.Assert.assertEquals;
+
 import com.google.cloud.TransportOptions;
-import org.easymock.EasyMock;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class LoggingOptionsTest {
+  private static final Boolean DONT_AUTO_POPULATE_METADATA = false;
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNonGrpcTransportOptions() {
+    TransportOptions invalidTransport = createMock(TransportOptions.class);
+    LoggingOptions.newBuilder().setTransportOptions(invalidTransport);
+  }
 
   @Test
-  public void testInvalidTransport() {
-    try {
-      LoggingOptions.newBuilder()
-          .setTransportOptions(EasyMock.<TransportOptions>createMock(TransportOptions.class));
-      Assert.fail();
-    } catch (IllegalArgumentException expected) {
-      Assert.assertNotNull(expected.getMessage());
-    }
+  public void testAutoPopulateMetadataOption() {
+    LoggingOptions actual =
+        LoggingOptions.newBuilder().setAutoPopulateMetadata(DONT_AUTO_POPULATE_METADATA).build();
+    assertEquals(DONT_AUTO_POPULATE_METADATA, actual.getAutoPopulateMetadata());
+  }
+
+  @Test
+  public void testAutoPopulateMetadataDefaultOption() {
+    LoggingOptions actual = LoggingOptions.getDefaultInstance();
+    assertEquals(Boolean.TRUE, actual.getAutoPopulateMetadata());
   }
 }

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingTest.java
@@ -43,6 +43,7 @@ public class LoggingTest {
   private static final String FOLDER_NAME = "folder";
   private static final String ORGANIZATION_NAME = "organization";
   private static final String BILLING_NAME = "billing";
+  private static final Boolean DONT_AUTO_POPULATE_METADATA = false;
 
   @Test
   public void testListOption() {
@@ -109,6 +110,10 @@ public class LoggingTest {
     writeOption = WriteOption.resource(RESOURCE);
     assertEquals(RESOURCE, writeOption.getValue());
     assertEquals(WriteOption.OptionType.RESOURCE, writeOption.getOptionType());
+
+    writeOption = WriteOption.autoPopulateMetadata(DONT_AUTO_POPULATE_METADATA);
+    assertEquals(DONT_AUTO_POPULATE_METADATA, writeOption.getValue());
+    assertEquals(WriteOption.OptionType.AUTO_POPULATE_METADATA, writeOption.getOptionType());
   }
 
   @Test


### PR DESCRIPTION
Provides opt-out configuration on the `Logging` instance and `Logging.write()` API levels to opt-out automatically populate empty metadata fields of the log entries being submitted for writing.

Fixes #689
