### PR TITLE
feat: auto-populate metadata of log entries at write()

### DIFF
--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Context.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Context.java
@@ -49,7 +49,7 @@ public class Context {
 
     /** Sets the HTTP request. */
     public Builder setRequest(HttpRequest request) {
-      this.requestBuilder = request.toBuilder();
+      this.requestBuilder = request != null ? request.toBuilder() : HttpRequest.newBuilder();
       return this;
     }
 

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -93,8 +93,8 @@ import java.util.concurrent.TimeoutException;
 
 class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
 
+  protected static final String RESOURCE_NAME_FORMAT = "projects/%s/traces/%s";
   private static final int FLUSH_WAIT_TIMEOUT_SECONDS = 6;
-  private static final String RESOURCE_NAME_FORMAT = "projects/%s/traces/%s";
   private final LoggingRpc rpc;
   private final Map<Object, ApiFuture<Void>> pendingWrites = new ConcurrentHashMap<>();
 
@@ -821,10 +821,10 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
           if (resourceMetadata != null && entry.getResource() == null) {
             builder.setResource(resourceMetadata);
           }
-          if (entry.getHttpRequest() == null) {
+          if (context != null && entry.getHttpRequest() == null) {
             builder.setHttpRequest(context.getHttpRequest());
           }
-          if (Strings.isNullOrEmpty(entry.getTrace())) {
+          if (context != null && Strings.isNullOrEmpty(entry.getTrace())) {
             // if project id can be retrieved from resource (environment) metadata
             // format trace id to support grouping and correlation
             if (context.getTraceId() != null) {
@@ -856,7 +856,7 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
               }
             }
           }
-          if (Strings.isNullOrEmpty(entry.getSpanId())) {
+          if (context != null && Strings.isNullOrEmpty(entry.getSpanId())) {
             builder.setSpanId(context.getSpanId());
           }
           if (entry.getSeverity() != null

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/MonitoredResourceUtil.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/MonitoredResourceUtil.java
@@ -33,6 +33,7 @@ import java.util.Map;
 public class MonitoredResourceUtil {
 
   private static final String APPENGINE_LABEL_PREFIX = "appengine.googleapis.com/";
+  public static final String PORJECTID_LABEL = Label.ProjectId.getKey();
 
   protected enum Label {
     ClusterName("cluster_name"),

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/MonitoredResourceUtil.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/MonitoredResourceUtil.java
@@ -33,7 +33,7 @@ import java.util.Map;
 public class MonitoredResourceUtil {
 
   private static final String APPENGINE_LABEL_PREFIX = "appengine.googleapis.com/";
-  public static final String PORJECTID_LABEL = Label.ProjectId.getKey();
+  protected static final String PORJECTID_LABEL = Label.ProjectId.getKey();
 
   protected enum Label {
     ClusterName("cluster_name"),

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/AutoPopulateMetadataTests.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/AutoPopulateMetadataTests.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.newCapture;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.google.api.core.ApiFutures;
+import com.google.cloud.MonitoredResource;
+import com.google.cloud.logging.HttpRequest.RequestMethod;
+import com.google.cloud.logging.Logging.WriteOption;
+import com.google.cloud.logging.spi.LoggingRpcFactory;
+import com.google.cloud.logging.spi.v2.LoggingRpc;
+import com.google.common.collect.ImmutableList;
+import com.google.logging.v2.WriteLogEntriesRequest;
+import com.google.logging.v2.WriteLogEntriesResponse;
+import org.easymock.Capture;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AutoPopulateMetadataTests {
+
+  private static final String LOG_NAME = "test-log";
+  private static final String RESOURCE_PROJECT_ID = "env-project-id";
+  private static final String LOGGING_PROJECT_ID = "log-project-id";
+  private static final MonitoredResource RESOURCE =
+      MonitoredResource.newBuilder("global")
+          .addLabel(MonitoredResourceUtil.PORJECTID_LABEL, RESOURCE_PROJECT_ID)
+          .build();
+  private static final LogEntry SIMPLE_LOG_ENTRY =
+      LogEntry.newBuilder(Payload.StringPayload.of("hello"))
+          .setLogName(LOG_NAME)
+          .setDestination(LogDestinationName.project(LOGGING_PROJECT_ID))
+          .build();
+  private static final LogEntry SIMPLE_LOG_ENTRY_WITH_DEBUG =
+      LogEntry.newBuilder(Payload.StringPayload.of("hello"))
+          .setLogName(LOG_NAME)
+          .setSeverity(Severity.DEBUG)
+          .setDestination(LogDestinationName.project(LOGGING_PROJECT_ID))
+          .build();
+  private static final WriteLogEntriesResponse EMPTY_WRITE_RESPONSE =
+      WriteLogEntriesResponse.newBuilder().build();
+  private static final HttpRequest HTTP_REQUEST =
+      HttpRequest.newBuilder()
+          .setRequestMethod(RequestMethod.GET)
+          .setRequestUrl("https://example.com")
+          .setUserAgent("Test User Agent")
+          .build();
+  private static final String TRACE_ID = "01010101010101010101010101010101";
+  private static final String FORMATTED_TRACE_ID =
+      String.format(LoggingImpl.RESOURCE_NAME_FORMAT, RESOURCE_PROJECT_ID, TRACE_ID);
+  private static final String SPAN_ID = "1";
+
+  private LoggingRpcFactory mockedRpcFactory;
+  private LoggingRpc mockedRpc;
+  private Logging logging;
+  private Capture<WriteLogEntriesRequest> rpcWriteArgument = newCapture();
+  private ResourceTypeEnvironmentGetter mockedEnvGetter;
+
+  @Before
+  public void setup() {
+    mockedEnvGetter = createMock(ResourceTypeEnvironmentGetter.class);
+    mockedRpcFactory = createMock(LoggingRpcFactory.class);
+    mockedRpc = createMock(LoggingRpc.class);
+    expect(mockedRpcFactory.create(anyObject(LoggingOptions.class)))
+        .andReturn(mockedRpc)
+        .anyTimes();
+    expect(mockedRpc.write(capture(rpcWriteArgument)))
+        .andReturn(ApiFutures.immediateFuture(EMPTY_WRITE_RESPONSE));
+    MonitoredResourceUtil.setEnvironmentGetter(mockedEnvGetter);
+    expect(mockedEnvGetter.getAttribute("project/project-id")).andStubReturn(RESOURCE_PROJECT_ID);
+    // following mock enforces to identify "Global" resource type
+    expect(mockedEnvGetter.getAttribute("")).andStubReturn(null);
+    replay(mockedRpcFactory, mockedRpc, mockedEnvGetter);
+
+    LoggingOptions options =
+        LoggingOptions.newBuilder()
+            .setProjectId(LOGGING_PROJECT_ID)
+            .setServiceRpcFactory(mockedRpcFactory)
+            .build();
+    logging = options.getService();
+  }
+
+  @After
+  public void teardown() {
+    (new ContextHandler()).removeCurrentContext();
+  }
+
+  private void mockCurrentContext(HttpRequest request, String traceId, String spanId) {
+    Context mockedContext =
+        Context.newBuilder().setRequest(request).setTraceId(traceId).setSpanId(spanId).build();
+    (new ContextHandler()).setCurrentContext(mockedContext);
+  }
+
+  @Test
+  public void testAutoPopulationEnabledInLoggingOptions() {
+    mockCurrentContext(HTTP_REQUEST, TRACE_ID, SPAN_ID);
+
+    logging.write(ImmutableList.of(SIMPLE_LOG_ENTRY));
+
+    LogEntry actual = LogEntry.fromPb(rpcWriteArgument.getValue().getEntries(0));
+    assertEquals(HTTP_REQUEST, actual.getHttpRequest());
+    assertEquals(FORMATTED_TRACE_ID, actual.getTrace());
+    assertEquals(SPAN_ID, actual.getSpanId());
+    assertEquals(RESOURCE, actual.getResource());
+  }
+
+  @Test
+  public void testAutoPopulationEnabledInWriteOptionsAndDisabledInLoggingOptions() {
+    LoggingOptions options =
+        LoggingOptions.newBuilder()
+            .setProjectId(LOGGING_PROJECT_ID)
+            .setServiceRpcFactory(mockedRpcFactory)
+            .setAutoPopulateMetadata(false)
+            .build();
+    logging = options.getService();
+    mockCurrentContext(HTTP_REQUEST, TRACE_ID, SPAN_ID);
+
+    logging.write(ImmutableList.of(SIMPLE_LOG_ENTRY), WriteOption.autoPopulateMetadata(true));
+
+    LogEntry actual = LogEntry.fromPb(rpcWriteArgument.getValue().getEntries(0));
+    assertEquals(HTTP_REQUEST, actual.getHttpRequest());
+    assertEquals(FORMATTED_TRACE_ID, actual.getTrace());
+    assertEquals(SPAN_ID, actual.getSpanId());
+    assertEquals(RESOURCE, actual.getResource());
+  }
+
+  @Test
+  public void testAutoPopulationDisabledInWriteOptions() {
+    mockCurrentContext(HTTP_REQUEST, TRACE_ID, SPAN_ID);
+
+    logging.write(ImmutableList.of(SIMPLE_LOG_ENTRY), WriteOption.autoPopulateMetadata(false));
+
+    LogEntry actual = LogEntry.fromPb(rpcWriteArgument.getValue().getEntries(0));
+    assertNull(actual.getHttpRequest());
+    assertNull(actual.getTrace());
+    assertNull(actual.getSpanId());
+    assertNull(actual.getResource());
+  }
+
+  @Test
+  public void testSourceLocationPopulation() {
+    SourceLocation expected = SourceLocation.fromCurrentContext(0);
+    logging.write(ImmutableList.of(SIMPLE_LOG_ENTRY_WITH_DEBUG));
+
+    LogEntry actual = LogEntry.fromPb(rpcWriteArgument.getValue().getEntries(0));
+    assertEquals(expected.getFile(), actual.getSourceLocation().getFile());
+    assertEquals(expected.getClass(), actual.getSourceLocation().getClass());
+    assertEquals(expected.getFunction(), actual.getSourceLocation().getFunction());
+    assertEquals(new Long(expected.getLine() + 1), actual.getSourceLocation().getLine());
+  }
+}

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/BaseSystemTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/BaseSystemTest.java
@@ -130,8 +130,6 @@ public class BaseSystemTest {
     return waitForLogs(logName, null, 1);
   }
 
-  private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-
   protected static Iterator<LogEntry> waitForLogs(Logging.EntryListOption[] options, int minLogs)
       throws InterruptedException {
     Page<LogEntry> page = logging.listLogEntries(options);

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -261,6 +261,9 @@ public class LoggingImplTest {
             .setProjectId(PROJECT)
             .setServiceRpcFactory(rpcFactoryMock)
             .setRetrySettings(ServiceOptions.getNoRetrySettings())
+            // disable auto-population for LoggingImpl class tests
+            // see {@see AutoPopulationTests} for auto-population tests
+            .setAutoPopulateMetadata(false)
             .build();
 
     // By default when calling ListLogEntries, we append a filter of last 24 hours.

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingOptionsTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingOptionsTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 public class LoggingOptionsTest {
   private static final Boolean DONT_AUTO_POPULATE_METADATA = false;
+  private static final String PROJECT_ID = "fake-project-id";
 
   @Test(expected = IllegalArgumentException.class)
   public void testNonGrpcTransportOptions() {
@@ -34,13 +35,16 @@ public class LoggingOptionsTest {
   @Test
   public void testAutoPopulateMetadataOption() {
     LoggingOptions actual =
-        LoggingOptions.newBuilder().setAutoPopulateMetadata(DONT_AUTO_POPULATE_METADATA).build();
+        LoggingOptions.newBuilder()
+            .setProjectId(PROJECT_ID)
+            .setAutoPopulateMetadata(DONT_AUTO_POPULATE_METADATA)
+            .build();
     assertEquals(DONT_AUTO_POPULATE_METADATA, actual.getAutoPopulateMetadata());
   }
 
   @Test
   public void testAutoPopulateMetadataDefaultOption() {
-    LoggingOptions actual = LoggingOptions.getDefaultInstance();
+    LoggingOptions actual = LoggingOptions.newBuilder().setProjectId(PROJECT_ID).build();
     assertEquals(Boolean.TRUE, actual.getAutoPopulateMetadata());
   }
 }


### PR DESCRIPTION
Implements auto-population of metadata (resource info, http requests, trace and span ids, source location).
Respects auto-population LoggingOptions configuration and WriteOption flag.

