### PR TITLE
feat: enable auto-population of missing metadata in logs and printing structured logs to stdout

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -134,3 +134,62 @@ custom_content: |
   ```
   com.google.cloud.examples.logging.snippets.AddLoggingHandler.handlers=com.google.cloud.logging.LoggingHandler
   ```
+
+  #### Alternative way to ingest logs in Google Cloud managed environments
+
+  If you use Java logger with the Cloud Logging Handler, you can configure the handler to output logs to `stdout` using
+  the [structured logging Json format](https://cloud.google.com/logging/docs/structured-logging#special-payload-fields).
+  To do this, add `com.google.cloud.logging.LoggingHandler.redirectToStdout=true` to the logger configuration file.
+  You can use this configuration when running applications in Google Cloud managed environments such as AppEngine, Cloud Run,
+  Cloud Function or GKE. The logger agent installed on these environments can capture STDOUT and ingest it into Cloud Logging.
+  The agent can parse structured logs printed to STDOUT and capture additional log metadata beside the log payload.
+  The parsed information includes severity, source location, user labels, http request and tracing information.
+
+  #### Auto-population of log entrys' metadata
+
+  LogEntry object metadata information such as [monitored resource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/MonitoredResource), 
+  [Http request](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) or 
+  [source location](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogEntrySourceLocation)
+  are automatically populated with information that the library retrieves from the execution context.
+  The library populates only empty (set to `null`) LogEntry fields.
+  This behavior in the `Logging` instance can be opted out via `LoggingOptions`.
+  Call `LoggingOptions.Builder.setAutoPopulateMetadata(false)` to configure logging options to opt-out the metadata auto-population.
+  Cloud Logging handler can be configured to opt-out automatic population of the metadata using the logger configuration.
+  To disable the metadata auto-population add `com.google.cloud.logging.LoggingHandler.autoPopulateMetadata=false`
+  to the logger configuration file.
+
+  The auto-population logic populates source location _only_ for log entries with `Severity.DEBUG` severity.
+  The execution context of the Http request and tracing information is maintained by `ContextHandler` class.
+  The context is managed in the scope of the thread.
+  If you do not use thread pools for multi-threading the `ContextHandler` can be configured to propagate the context
+  to the scope of the child threads.
+  To enable this add `com.google.cloud.logging.ContextHandler.useInheritedContext=true` to the logger configuration file.
+  The library provides two methods to update the context:
+
+  * Manually set the context. You can use the following methods of the `Context.Builder` to set the context information.
+  Use the method `setRequest()` to setup the `HttpRequest` instance or `setRequestUrl()`, `setRequestMethod()`,
+  `setReferer() `, `setRemoteIp()` and `setServerIp()` to setup the fields of the `HttpRequest`.
+  The trace and span Ids can be set directly using `setTraceId()` and `setSpanId()` respectively.
+  Alternatively it can be parsed from the W3C tracing context header using `loadW3CTraceParentContext()` or
+  from the Google Cloud tracing context header using `loadCloudTraceContext()`.
+
+      ```java
+      Context context = Context.newBuilder().setHttpRequest(request).setTrace(traceId).setSpanId(spanId).build();
+      (new ContextHandler()).setCurrentContext(context);
+      ```
+
+  * Using [servlet initializer](https://github.com/googleapis/java-logging-servlet-initializer).
+  If your application uses a Web server based on Jakarta servlets (e.g. Jetty or Tomcat), you can add the servlet initializer
+  package to your WAR. The package implements a service provider interface (SPI) for
+  [javax.servlet.ServletContainerInitializer](https://docs.oracle.com/javaee/6/api/javax/servlet/ServletContainerInitializer.html)
+  and filters all servlet requests to automatically capture the execution context of the servlet request and store it using
+  `ContextHandler` class. The stored `Context` class instances are used to populate Http request and tracing information.
+  If you use Maven, to use the servlet initializer add the following dependency to your BOM:
+
+      ```xml
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-logging-servlet-initializer</artifactId>
+      </dependency>      
+      ```
+

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:24.1.1')
+implementation platform('com.google.cloud:libraries-bom:24.1.2')
 
 implementation 'com.google.cloud:google-cloud-logging'
 ```

--- a/README.md
+++ b/README.md
@@ -235,6 +235,64 @@ file. Adding, for instance, the following line:
 com.google.cloud.examples.logging.snippets.AddLoggingHandler.handlers=com.google.cloud.logging.LoggingHandler
 ```
 
+#### Alternative way to ingest logs in Google Cloud managed environments
+
+If you use Java logger with the Cloud Logging Handler, you can configure the handler to output logs to `stdout` using
+the [structured logging Json format](https://cloud.google.com/logging/docs/structured-logging#special-payload-fields).
+To do this, add `com.google.cloud.logging.LoggingHandler.redirectToStdout=true` to the logger configuration file.
+You can use this configuration when running applications in Google Cloud managed environments such as AppEngine, Cloud Run,
+Cloud Function or GKE. The logger agent installed on these environments can capture STDOUT and ingest it into Cloud Logging.
+The agent can parse structured logs printed to STDOUT and capture additional log metadata beside the log payload.
+The parsed information includes severity, source location, user labels, http request and tracing information.
+
+#### Auto-population of log entrys' metadata
+
+LogEntry object metadata information such as [monitored resource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/MonitoredResource), 
+[Http request](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) or 
+[source location](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogEntrySourceLocation)
+are automatically populated with information that the library retrieves from the execution context.
+The library populates only empty (set to `null`) LogEntry fields.
+This behavior in the `Logging` instance can be opted out via `LoggingOptions`.
+Call `LoggingOptions.Builder.setAutoPopulateMetadata(false)` to configure logging options to opt-out the metadata auto-population.
+Cloud Logging handler can be configured to opt-out automatic population of the metadata using the logger configuration.
+To disable the metadata auto-population add `com.google.cloud.logging.LoggingHandler.autoPopulateMetadata=false`
+to the logger configuration file.
+
+The auto-population logic populates source location _only_ for log entries with `Severity.DEBUG` severity.
+The execution context of the Http request and tracing information is maintained by `ContextHandler` class.
+The context is managed in the scope of the thread.
+If you do not use thread pools for multi-threading the `ContextHandler` can be configured to propagate the context
+to the scope of the child threads.
+To enable this add `com.google.cloud.logging.ContextHandler.useInheritedContext=true` to the logger configuration file.
+The library provides two methods to update the context:
+
+* Manually set the context. You can use the following methods of the `Context.Builder` to set the context information.
+Use the method `setRequest()` to setup the `HttpRequest` instance or `setRequestUrl()`, `setRequestMethod()`,
+`setReferer() `, `setRemoteIp()` and `setServerIp()` to setup the fields of the `HttpRequest`.
+The trace and span Ids can be set directly using `setTraceId()` and `setSpanId()` respectively.
+Alternatively it can be parsed from the W3C tracing context header using `loadW3CTraceParentContext()` or
+from the Google Cloud tracing context header using `loadCloudTraceContext()`.
+
+    ```java
+    Context context = Context.newBuilder().setHttpRequest(request).setTrace(traceId).setSpanId(spanId).build();
+    (new ContextHandler()).setCurrentContext(context);
+    ```
+
+* Using [servlet initializer](https://github.com/googleapis/java-logging-servlet-initializer).
+If your application uses a Web server based on Jakarta servlets (e.g. Jetty or Tomcat), you can add the servlet initializer
+package to your WAR. The package implements a service provider interface (SPI) for
+[javax.servlet.ServletContainerInitializer](https://docs.oracle.com/javaee/6/api/javax/servlet/ServletContainerInitializer.html)
+and filters all servlet requests to automatically capture the execution context of the servlet request and store it using
+`ContextHandler` class. The stored `Context` class instances are used to populate Http request and tracing information.
+If you use Maven, to use the servlet initializer add the following dependency to your BOM:
+
+    ```xml
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-logging-servlet-initializer</artifactId>
+    </dependency>      
+    ```
+
 
 
 

--- a/google-cloud-logging/clirr-ignored-differences.xml
+++ b/google-cloud-logging/clirr-ignored-differences.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/logging/Logging</className>
+    <method>java.lang.Iterable populateMetadata(java.lang.Iterable, com.google.cloud.MonitoredResource, java.lang.String[])</method>
+  </difference>
+</differences>

--- a/google-cloud-logging/pom.xml
+++ b/google-cloud-logging/pom.xml
@@ -22,6 +22,11 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.9</version>
+    </dependency>
+    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
     </dependency>

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Context.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Context.java
@@ -49,7 +49,7 @@ public class Context {
 
     /** Sets the HTTP request. */
     public Builder setRequest(HttpRequest request) {
-      this.requestBuilder = request.toBuilder();
+      this.requestBuilder = request != null ? request.toBuilder() : HttpRequest.newBuilder();
       return this;
     }
 

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
@@ -653,7 +653,7 @@ public class LogEntry implements Serializable {
       checkNotNull(name);
       if (value != null) {
         builder.append(gson.toJson(name)).append(":").append(gson.toJson(value));
-        if (!appendComma) {
+        if (appendComma) {
           builder.append(",");
         }
       }
@@ -661,7 +661,7 @@ public class LogEntry implements Serializable {
     }
 
     public StructuredLogFormatter appendField(String name, Object value) {
-      return appendField(name, value, false);
+      return appendField(name, value, true);
     }
 
     /**
@@ -677,7 +677,7 @@ public class LogEntry implements Serializable {
         // append json object without brackets
         if (json.length() > 1) {
           builder.append(json.substring(0, json.length() - 1).substring(1));
-          if (!appendComma) {
+          if (appendComma) {
             builder.append(",");
           }
         }
@@ -710,10 +710,10 @@ public class LogEntry implements Serializable {
         .appendField("logging.googleapis.com/trace", trace)
         .appendField("logging.googleapis.com/trace_sampled", traceSampled);
     if (payload.getType() == Type.STRING) {
-      formatter.appendField("message", payload.getData(), true);
+      formatter.appendField("message", payload.getData(), false);
     } else if (payload.getType() == Type.JSON) {
       Payload.JsonPayload jsonPayload = (Payload.JsonPayload) payload;
-      formatter.appendDict(jsonPayload.getDataAsMap(), true);
+      formatter.appendDict(jsonPayload.getDataAsMap(), false);
     }
     builder.append("}");
     return builder.toString();

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
@@ -19,9 +19,17 @@ package com.google.cloud.logging;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.cloud.MonitoredResource;
+import com.google.cloud.logging.Payload.Type;
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 import com.google.logging.v2.LogEntryOperation;
 import com.google.logging.v2.LogEntrySourceLocation;
 import com.google.logging.v2.LogName;
@@ -61,8 +69,8 @@ public class LogEntry implements Serializable {
   private final HttpRequest httpRequest;
   private final Map<String, String> labels;
   private final Operation operation;
-  private final Object trace;
-  private final Object spanId;
+  private final String trace;
+  private final String spanId;
   private final boolean traceSampled;
   private final SourceLocation sourceLocation;
   private final Payload<?> payload;
@@ -80,8 +88,8 @@ public class LogEntry implements Serializable {
     private HttpRequest httpRequest;
     private Map<String, String> labels = new HashMap<>();
     private Operation operation;
-    private Object trace;
-    private Object spanId;
+    private String trace;
+    private String spanId;
     private boolean traceSampled;
     private SourceLocation sourceLocation;
     private Payload<?> payload;
@@ -245,7 +253,7 @@ public class LogEntry implements Serializable {
      * relative resource name, the name is assumed to be relative to `//tracing.googleapis.com`.
      */
     public Builder setTrace(Object trace) {
-      this.trace = trace;
+      this.trace = trace != null ? trace.toString() : null;
       return this;
     }
 
@@ -257,7 +265,7 @@ public class LogEntry implements Serializable {
 
     /** Sets the ID of the trace span associated with the log entry, if any. */
     public Builder setSpanId(Object spanId) {
-      this.spanId = spanId;
+      this.spanId = spanId != null ? spanId.toString() : null;
       return this;
     }
 
@@ -573,6 +581,142 @@ public class LogEntry implements Serializable {
       builder.setSourceLocation(sourceLocation.toPb());
     }
     return builder.build();
+  }
+
+  /**
+   * Customized serializers to match the expected format for timestamp, source location and request
+   * method
+   */
+  static final class InstantSerializer implements JsonSerializer<Instant> {
+    @Override
+    public JsonElement serialize(
+        Instant src, java.lang.reflect.Type typeOfSrc, JsonSerializationContext context) {
+      return new JsonPrimitive(src.toString());
+    }
+  }
+
+  static final class SourceLocationSerializer implements JsonSerializer<SourceLocation> {
+    @Override
+    public JsonElement serialize(
+        SourceLocation src, java.lang.reflect.Type typeOfSrc, JsonSerializationContext context) {
+      JsonObject obj = new JsonObject();
+      if (src.getFile() != null) {
+        obj.addProperty("file", src.getFile());
+      }
+      if (src.getLine() != null) {
+        obj.addProperty("line", src.getLine().toString());
+      }
+      if (src.getFunction() != null) {
+        obj.addProperty("function", src.getFunction());
+      }
+      return obj;
+    }
+  }
+
+  static final class RequestMethodSerializer implements JsonSerializer<HttpRequest.RequestMethod> {
+    @Override
+    public JsonElement serialize(
+        HttpRequest.RequestMethod src,
+        java.lang.reflect.Type typeOfSrc,
+        JsonSerializationContext context) {
+      return new JsonPrimitive(src.name());
+    }
+  }
+
+  /** Helper class to format one line Json representation of the LogEntry for structured log. */
+  static final class StructuredLogFormatter {
+    private final Gson gson;
+    private final StringBuilder builder;
+
+    public StructuredLogFormatter(StringBuilder builder) {
+      checkNotNull(builder);
+      this.gson =
+          new GsonBuilder()
+              .registerTypeAdapter(Instant.class, new InstantSerializer())
+              .registerTypeAdapter(SourceLocation.class, new SourceLocationSerializer())
+              .registerTypeAdapter(HttpRequest.RequestMethod.class, new RequestMethodSerializer())
+              .create();
+      this.builder = builder;
+    }
+
+    /**
+     * Adds a Json field and value pair to the current string representation. Method does not
+     * validate parameters to be multi-line strings. Nothing is added if {@code value} parameter is
+     * {@code null}.
+     *
+     * @param name a valid Json field name string.
+     * @param value an object to be serialized to Json using {@link Gson}.
+     * @param appendComma a flag to add a trailing comma.
+     * @return a reference to this object.
+     */
+    public StructuredLogFormatter appendField(String name, Object value, boolean appendComma) {
+      checkNotNull(name);
+      if (value != null) {
+        builder.append(gson.toJson(name)).append(":").append(gson.toJson(value));
+        if (!appendComma) {
+          builder.append(",");
+        }
+      }
+      return this;
+    }
+
+    public StructuredLogFormatter appendField(String name, Object value) {
+      return appendField(name, value, false);
+    }
+
+    /**
+     * Serializes a dictionary of key, values as Json fields.
+     *
+     * @param value a {@link Map} of key, value arguments to be serialized using {@link Gson}.
+     * @param appendComma a flag to add a trailing comma.
+     * @return a reference to this object.
+     */
+    public StructuredLogFormatter appendDict(Map<String, Object> value, boolean appendComma) {
+      if (value != null) {
+        String json = gson.toJson(value);
+        // append json object without brackets
+        if (json.length() > 1) {
+          builder.append(json.substring(0, json.length() - 1).substring(1));
+          if (!appendComma) {
+            builder.append(",");
+          }
+        }
+      }
+      return this;
+    }
+  }
+
+  /**
+   * Serializes the object to a one line JSON string in the simplified format that can be parsed by
+   * the logging agents that run on Google Cloud resources.
+   */
+  public String toStructuredJsonString() {
+    if (payload.getType() == Type.PROTO) {
+      throw new UnsupportedOperationException("LogEntry with protobuf payload cannot be converted");
+    }
+
+    final StringBuilder builder = new StringBuilder("{");
+    final StructuredLogFormatter formatter = new StructuredLogFormatter(builder);
+
+    formatter
+        .appendField("severity", severity)
+        .appendField("timestamp", timestamp)
+        .appendField("httpRequest", httpRequest)
+        .appendField("logging.googleapis.com/insertId", insertId)
+        .appendField("logging.googleapis.com/labels", labels)
+        .appendField("logging.googleapis.com/operation", operation)
+        .appendField("logging.googleapis.com/sourceLocation", sourceLocation)
+        .appendField("logging.googleapis.com/spanId", spanId)
+        .appendField("logging.googleapis.com/trace", trace)
+        .appendField("logging.googleapis.com/trace_sampled", traceSampled);
+    if (payload.getType() == Type.STRING) {
+      formatter.appendField("message", payload.getData(), true);
+    } else if (payload.getType() == Type.JSON) {
+      Payload.JsonPayload jsonPayload = (Payload.JsonPayload) payload;
+      formatter.appendDict(jsonPayload.getDataAsMap(), true);
+    }
+    builder.append("}");
+    return builder.toString();
   }
 
   /** Returns a builder for {@code LogEntry} objects given the entry payload. */

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
@@ -1286,8 +1286,30 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
    * </pre>
    */
   @BetaApi("The surface for the tail streaming is not stable yet and may change in the future.")
-  default LogEntryServerStream tailLogEntries(TailOption... options) {
+  LogEntryServerStream tailLogEntries(TailOption... options);
+
+  /**
+   * Populates metadata fields of the immutable collection of {@link LogEntry} items. Only empty
+   * fields are populated. The {@link SourceLocation} is populated only for items with the severity
+   * set to {@link Severity.DEBUG}. The information about {@link HttpRequest}, trace and span Id is
+   * retrieved using {@link ContextHandler}.
+   *
+   * @param logEntries an immutable collection of {@link LogEntry} items.
+   * @param customResource a customized instance of the {@link MonitoredResource}. If this parameter
+   *     is {@code null} then the new instance will be generated using {@link
+   *     MonitoredResourceUtil#getResource(String, String)}.
+   * @param exclusionClassPaths a list of exclussion class path prefixes. If left empty then {@link
+   *     SourceLocation} instance is built based on the caller's stack trace information. Otherwise,
+   *     the information from the first {@link StackTraceElement} along the call stack which class
+   *     name does not start with any not {@code null} exclusion class paths is used.
+   * @return A collection of {@link LogEntry} items composed from the {@code logEntries} parameter
+   *     with populated metadata fields.
+   */
+  default Iterable<LogEntry> populateMetadata(
+      Iterable<LogEntry> logEntries,
+      MonitoredResource customResource,
+      String... exclusionClassPaths) {
     throw new UnsupportedOperationException(
-        "method tailLogEntriesCallable() does not have default implementation");
+        "method populateMetadata() does not have default implementation");
   }
 }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
@@ -70,7 +70,8 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
       LOG_NAME,
       RESOURCE,
       LABELS,
-      LOG_DESTINATION;
+      LOG_DESTINATION,
+      AUTO_POPULATE_METADATA;
 
       @SuppressWarnings("unchecked")
       <T> T get(Map<Option.OptionType, ?> options) {
@@ -113,6 +114,14 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
      */
     public static WriteOption destination(LogDestinationName destination) {
       return new WriteOption(OptionType.LOG_DESTINATION, destination);
+    }
+
+    /**
+     * Returns an option to opt-out automatic population of log entries metadata fields that are not
+     * set.
+     */
+    public static WriteOption autoPopulateMetadata(boolean autoPopulateMetadata) {
+      return new WriteOption(OptionType.AUTO_POPULATE_METADATA, autoPopulateMetadata);
     }
   }
 

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingConfig.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingConfig.java
@@ -42,6 +42,7 @@ class LoggingConfig {
   private static final String ENHANCERS_TAG = "enhancers";
   private static final String USE_INHERITED_CONTEXT = "useInheritedContext";
   private static final String AUTO_POPULATE_METADATA = "autoPopulateMetadata";
+  private static final String REDIRECT_TO_STDOUT = "redirectToStdout";
 
   public LoggingConfig(String className) {
     this.className = className;
@@ -78,11 +79,11 @@ class LoggingConfig {
   }
 
   Boolean getAutoPopulateMetadata() {
-    String flag = getProperty(AUTO_POPULATE_METADATA);
-    if (flag != null) {
-      return Boolean.parseBoolean(flag);
-    }
-    return null;
+    return getBooleanProperty(AUTO_POPULATE_METADATA, null);
+  }
+
+  Boolean getRedirectToStdout() {
+    return getBooleanProperty(REDIRECT_TO_STDOUT, null);
   }
 
   MonitoredResource getMonitoredResource(String projectId) {
@@ -125,6 +126,14 @@ class LoggingConfig {
 
   private String getProperty(String name, String defaultValue) {
     return firstNonNull(getProperty(name), defaultValue);
+  }
+
+  private Boolean getBooleanProperty(String name, Boolean defaultValue) {
+    String flag = getProperty(name);
+    if (flag != null) {
+      return Boolean.parseBoolean(flag);
+    }
+    return defaultValue;
   }
 
   private Level getLevelProperty(String name, Level defaultValue) {

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingConfig.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingConfig.java
@@ -41,6 +41,7 @@ class LoggingConfig {
   private static final String RESOURCE_TYPE_TAG = "resourceType";
   private static final String ENHANCERS_TAG = "enhancers";
   private static final String USE_INHERITED_CONTEXT = "useInheritedContext";
+  private static final String AUTO_POPULATE_METADATA = "autoPopulateMetadata";
 
   public LoggingConfig(String className) {
     this.className = className;
@@ -74,6 +75,14 @@ class LoggingConfig {
 
   Formatter getFormatter() {
     return getFormatterProperty(FORMATTER_TAG, new SimpleFormatter());
+  }
+
+  Boolean getAutoPopulateMetadata() {
+    String flag = getProperty(AUTO_POPULATE_METADATA);
+    if (flag != null) {
+      return Boolean.parseBoolean(flag);
+    }
+    return null;
   }
 
   MonitoredResource getMonitoredResource(String projectId) {

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingConfig.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingConfig.java
@@ -88,10 +88,11 @@ class LoggingConfig {
       if (list != null) {
         String[] items = list.split(",");
         for (String e_name : items) {
-          Class<? extends LoggingEnhancer> clz =
-              (Class<? extends LoggingEnhancer>)
-                  ClassLoader.getSystemClassLoader().loadClass(e_name);
-          enhancers.add(clz.getDeclaredConstructor().newInstance());
+          Class<? extends LoggingEnhancer> clazz =
+              ClassLoader.getSystemClassLoader()
+                  .loadClass(e_name)
+                  .asSubclass(LoggingEnhancer.class);
+          enhancers.add(clazz.getDeclaredConstructor().newInstance());
         }
       }
       return enhancers;

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingHandler.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingHandler.java
@@ -380,9 +380,7 @@ public class LoggingHandler extends Handler {
     return getLogging().getWriteSynchronicity();
   }
 
-  /**
-   * Sets the metadata auto population flag.
-   */
+  /** Sets the metadata auto population flag. */
   public void setAutoPopulateMetadata(Boolean value) {
     checkNotNull(value);
     this.autoPopulateMetadata = value;

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -24,6 +24,7 @@ import static com.google.cloud.logging.Logging.WriteOption.OptionType.LABELS;
 import static com.google.cloud.logging.Logging.WriteOption.OptionType.LOG_DESTINATION;
 import static com.google.cloud.logging.Logging.WriteOption.OptionType.LOG_NAME;
 import static com.google.cloud.logging.Logging.WriteOption.OptionType.RESOURCE;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.client.util.Strings;
 import com.google.api.core.ApiFunction;
@@ -41,7 +42,6 @@ import com.google.cloud.PageImpl;
 import com.google.cloud.logging.spi.v2.LoggingRpc;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -459,10 +459,10 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
 
   @Override
   public ApiFuture<Boolean> deleteLogAsync(String log, LogDestinationName destination) {
-    Preconditions.checkNotNull(log, "log parameter cannot be null");
+    checkNotNull(log, "log parameter cannot be null");
     String projectId = getOptions().getProjectId();
     if (destination == null) {
-      Preconditions.checkNotNull(projectId, "projectId parameter cannot be null");
+      checkNotNull(projectId, "projectId parameter cannot be null");
     }
     LogName name = getLogName(projectId, log, destination);
     DeleteLogRequest request = DeleteLogRequest.newBuilder().setLogName(name.toString()).build();
@@ -792,6 +792,54 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
     return destination.toLogName(logName);
   }
 
+  public Iterable<LogEntry> populateMetadata(
+      Iterable<LogEntry> logEntries,
+      MonitoredResource customResource,
+      String... exclusionClassPaths) {
+    checkNotNull(logEntries);
+    final Boolean needDebugInfo =
+        Iterables.any(
+            logEntries,
+            log -> log.getSeverity() == Severity.DEBUG && log.getSourceLocation() == null);
+    final SourceLocation sourceLocation =
+        needDebugInfo ? SourceLocation.fromCurrentContext(exclusionClassPaths) : null;
+    // populate monitored resource metadata by prioritizing the one set via
+    // WriteOption
+    final MonitoredResource resourceMetadata =
+        customResource == null
+            ? MonitoredResourceUtil.getResource(getOptions().getProjectId(), null)
+            : customResource;
+    final Context context = (new ContextHandler()).getCurrentContext();
+    final ArrayList<LogEntry> populatedLogEntries = Lists.newArrayList();
+
+    // populate empty metadata fields of log entries before calling write API
+    for (LogEntry entry : logEntries) {
+      if (entry == null) {
+        continue;
+      }
+      LogEntry.Builder entityBuilder = entry.toBuilder();
+      if (resourceMetadata != null && entry.getResource() == null) {
+        entityBuilder.setResource(resourceMetadata);
+      }
+      if (context != null && entry.getHttpRequest() == null) {
+        entityBuilder.setHttpRequest(context.getHttpRequest());
+      }
+      if (context != null && Strings.isNullOrEmpty(entry.getTrace())) {
+        MonitoredResource resource =
+            entry.getResource() != null ? entry.getResource() : resourceMetadata;
+        entityBuilder.setTrace(getFormattedTrace(context.getTraceId(), resource));
+      }
+      if (context != null && Strings.isNullOrEmpty(entry.getSpanId())) {
+        entityBuilder.setSpanId(context.getSpanId());
+      }
+      if (entry.getSeverity() == Severity.DEBUG && entry.getSourceLocation() == null) {
+        entityBuilder.setSourceLocation(sourceLocation);
+      }
+      populatedLogEntries.add(entityBuilder.build());
+    }
+    return populatedLogEntries;
+  }
+
   public void write(Iterable<LogEntry> logEntries, WriteOption... options) {
     if (inWriteCall.get() != null) {
       return;
@@ -806,46 +854,9 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
 
       if (populateMetadata2 == Boolean.TRUE
           || (populateMetadata2 == null && populateMetadata1 == Boolean.TRUE)) {
-        final Boolean needDebugInfo =
-            Iterables.any(
-                logEntries,
-                log -> log.getSeverity() == Severity.DEBUG && log.getSourceLocation() == null);
-        final SourceLocation sourceLocation =
-            needDebugInfo ? SourceLocation.fromCurrentContext(1) : null;
         final MonitoredResource sharedResourceMetadata = RESOURCE.get(writeOptions);
-        // populate monitored resource metadata by prioritizing the one set via WriteOption
-        final MonitoredResource resourceMetadata =
-            sharedResourceMetadata == null
-                ? MonitoredResourceUtil.getResource(getOptions().getProjectId(), null)
-                : sharedResourceMetadata;
-        final Context context = (new ContextHandler()).getCurrentContext();
-        final ArrayList<LogEntry> populatedLogEntries = Lists.newArrayList();
-
-        // populate empty metadata fields of log entries before calling write API
-        for (LogEntry entry : logEntries) {
-          LogEntry.Builder builder = entry.toBuilder();
-          if (resourceMetadata != null && entry.getResource() == null) {
-            builder.setResource(resourceMetadata);
-          }
-          if (context != null && entry.getHttpRequest() == null) {
-            builder.setHttpRequest(context.getHttpRequest());
-          }
-          if (context != null && Strings.isNullOrEmpty(entry.getTrace())) {
-            MonitoredResource resource =
-                entry.getResource() != null ? entry.getResource() : resourceMetadata;
-            builder.setTrace(getFormattedTrace(context.getTraceId(), resource));
-          }
-          if (context != null && Strings.isNullOrEmpty(entry.getSpanId())) {
-            builder.setSpanId(context.getSpanId());
-          }
-          if (entry.getSeverity() != null
-              && entry.getSeverity() == Severity.DEBUG
-              && entry.getSourceLocation() == null) {
-            builder.setSourceLocation(sourceLocation);
-          }
-          populatedLogEntries.add(builder.build());
-        }
-        logEntries = populatedLogEntries;
+        logEntries =
+            populateMetadata(logEntries, sharedResourceMetadata, this.getClass().getName());
       }
 
       writeLogEntries(logEntries, options);

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -848,12 +848,12 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
 
     try {
       final Map<Option.OptionType, ?> writeOptions = optionMap(options);
-      final Boolean populateMetadata1 = getOptions().getAutoPopulateMetadata();
-      final Boolean populateMetadata2 =
+      final Boolean logingOptionsPopulateFlag = getOptions().getAutoPopulateMetadata();
+      final Boolean writeOptionPopulateFlga =
           WriteOption.OptionType.AUTO_POPULATE_METADATA.get(writeOptions);
 
-      if (populateMetadata2 == Boolean.TRUE
-          || (populateMetadata2 == null && populateMetadata1 == Boolean.TRUE)) {
+      if (writeOptionPopulateFlga == Boolean.TRUE
+          || (writeOptionPopulateFlga == null && logingOptionsPopulateFlag == Boolean.TRUE)) {
         final MonitoredResource sharedResourceMetadata = RESOURCE.get(writeOptions);
         logEntries =
             populateMetadata(logEntries, sharedResourceMetadata, this.getClass().getName());

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingOptions.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingOptions.java
@@ -38,6 +38,8 @@ public class LoggingOptions extends ServiceOptions<Logging, LoggingOptions> {
   private static final String DEFAULT_HOST = LoggingSettings.getDefaultEndpoint();
   private static final long serialVersionUID = 5753499510627426717L;
 
+  private Boolean autoPopulateMetadataOnWrite = null;
+
   public static class DefaultLoggingFactory implements LoggingFactory {
     private static final LoggingFactory INSTANCE = new DefaultLoggingFactory();
 
@@ -72,6 +74,8 @@ public class LoggingOptions extends ServiceOptions<Logging, LoggingOptions> {
 
   public static class Builder extends ServiceOptions.Builder<Logging, LoggingOptions, Builder> {
 
+    private Boolean autoPopulateMetadataOnWrite = true;
+
     private Builder() {}
 
     private Builder(LoggingOptions options) {
@@ -87,6 +91,11 @@ public class LoggingOptions extends ServiceOptions<Logging, LoggingOptions> {
       return super.setTransportOptions(transportOptions);
     }
 
+    public Builder setAutoPopulateMetadata(boolean autoPopulateMetadataOnWrite) {
+      this.autoPopulateMetadataOnWrite = autoPopulateMetadataOnWrite;
+      return this;
+    }
+
     @Override
     public LoggingOptions build() {
       return new LoggingOptions(this);
@@ -96,6 +105,7 @@ public class LoggingOptions extends ServiceOptions<Logging, LoggingOptions> {
   @InternalApi("This class should only be extended within google-cloud-java")
   protected LoggingOptions(Builder builder) {
     super(LoggingFactory.class, LoggingRpcFactory.class, builder, new LoggingDefaults());
+    this.autoPopulateMetadataOnWrite = builder.autoPopulateMetadataOnWrite;
   }
 
   @SuppressWarnings("serial")
@@ -128,6 +138,10 @@ public class LoggingOptions extends ServiceOptions<Logging, LoggingOptions> {
 
   protected LoggingRpc getLoggingRpcV2() {
     return (LoggingRpc) getRpc();
+  }
+
+  public Boolean getAutoPopulateMetadata() {
+    return this.autoPopulateMetadataOnWrite;
   }
 
   @Override

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/MonitoredResourceUtil.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/MonitoredResourceUtil.java
@@ -33,6 +33,7 @@ import java.util.Map;
 public class MonitoredResourceUtil {
 
   private static final String APPENGINE_LABEL_PREFIX = "appengine.googleapis.com/";
+  protected static final String PORJECTID_LABEL = Label.ProjectId.getKey();
 
   protected enum Label {
     ClusterName("cluster_name"),

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/AutoPopulateMetadataTests.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/AutoPopulateMetadataTests.java
@@ -89,7 +89,8 @@ public class AutoPopulateMetadataTests {
     expect(mockedRpc.write(capture(rpcWriteArgument)))
         .andReturn(ApiFutures.immediateFuture(EMPTY_WRITE_RESPONSE));
     MonitoredResourceUtil.setEnvironmentGetter(mockedEnvGetter);
-    // the following mocks generate MonitoredResource instance same as RESOURCE constant
+    // the following mocks generate MonitoredResource instance same as RESOURCE
+    // constant
     expect(mockedEnvGetter.getAttribute("project/project-id")).andStubReturn(RESOURCE_PROJECT_ID);
     expect(mockedEnvGetter.getAttribute("")).andStubReturn(null);
     replay(mockedRpcFactory, mockedRpc, mockedEnvGetter);
@@ -158,7 +159,7 @@ public class AutoPopulateMetadataTests {
 
   @Test
   public void testSourceLocationPopulation() {
-    SourceLocation expected = SourceLocation.fromCurrentContext(0);
+    SourceLocation expected = SourceLocation.fromCurrentContext();
     logging.write(ImmutableList.of(SIMPLE_LOG_ENTRY_WITH_DEBUG));
 
     LogEntry actual = LogEntry.fromPb(rpcWriteArgument.getValue().getEntries(0));

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/AutoPopulateMetadataTests.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/AutoPopulateMetadataTests.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.newCapture;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.google.api.core.ApiFutures;
+import com.google.cloud.MonitoredResource;
+import com.google.cloud.logging.HttpRequest.RequestMethod;
+import com.google.cloud.logging.Logging.WriteOption;
+import com.google.cloud.logging.spi.LoggingRpcFactory;
+import com.google.cloud.logging.spi.v2.LoggingRpc;
+import com.google.common.collect.ImmutableList;
+import com.google.logging.v2.WriteLogEntriesRequest;
+import com.google.logging.v2.WriteLogEntriesResponse;
+import org.easymock.Capture;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AutoPopulateMetadataTests {
+
+  private static final String LOG_NAME = "test-log";
+  private static final String RESOURCE_PROJECT_ID = "env-project-id";
+  private static final String LOGGING_PROJECT_ID = "log-project-id";
+  private static final MonitoredResource RESOURCE =
+      MonitoredResource.newBuilder("global")
+          .addLabel(MonitoredResourceUtil.PORJECTID_LABEL, RESOURCE_PROJECT_ID)
+          .build();
+  private static final LogEntry SIMPLE_LOG_ENTRY =
+      LogEntry.newBuilder(Payload.StringPayload.of("hello"))
+          .setLogName(LOG_NAME)
+          .setDestination(LogDestinationName.project(LOGGING_PROJECT_ID))
+          .build();
+  private static final LogEntry SIMPLE_LOG_ENTRY_WITH_DEBUG =
+      LogEntry.newBuilder(Payload.StringPayload.of("hello"))
+          .setLogName(LOG_NAME)
+          .setSeverity(Severity.DEBUG)
+          .setDestination(LogDestinationName.project(LOGGING_PROJECT_ID))
+          .build();
+  private static final WriteLogEntriesResponse EMPTY_WRITE_RESPONSE =
+      WriteLogEntriesResponse.newBuilder().build();
+  private static final HttpRequest HTTP_REQUEST =
+      HttpRequest.newBuilder()
+          .setRequestMethod(RequestMethod.GET)
+          .setRequestUrl("https://example.com")
+          .setUserAgent("Test User Agent")
+          .build();
+  private static final String TRACE_ID = "01010101010101010101010101010101";
+  private static final String FORMATTED_TRACE_ID =
+      String.format(LoggingImpl.RESOURCE_NAME_FORMAT, RESOURCE_PROJECT_ID, TRACE_ID);
+  private static final String SPAN_ID = "1";
+
+  private LoggingRpcFactory mockedRpcFactory;
+  private LoggingRpc mockedRpc;
+  private Logging logging;
+  private Capture<WriteLogEntriesRequest> rpcWriteArgument = newCapture();
+  private ResourceTypeEnvironmentGetter mockedEnvGetter;
+
+  @Before
+  public void setup() {
+    mockedEnvGetter = createMock(ResourceTypeEnvironmentGetter.class);
+    mockedRpcFactory = createMock(LoggingRpcFactory.class);
+    mockedRpc = createMock(LoggingRpc.class);
+    expect(mockedRpcFactory.create(anyObject(LoggingOptions.class)))
+        .andReturn(mockedRpc)
+        .anyTimes();
+    expect(mockedRpc.write(capture(rpcWriteArgument)))
+        .andReturn(ApiFutures.immediateFuture(EMPTY_WRITE_RESPONSE));
+    MonitoredResourceUtil.setEnvironmentGetter(mockedEnvGetter);
+    // the following mocks generate MonitoredResource instance same as RESOURCE constant
+    expect(mockedEnvGetter.getAttribute("project/project-id")).andStubReturn(RESOURCE_PROJECT_ID);
+    expect(mockedEnvGetter.getAttribute("")).andStubReturn(null);
+    replay(mockedRpcFactory, mockedRpc, mockedEnvGetter);
+
+    LoggingOptions options =
+        LoggingOptions.newBuilder()
+            .setProjectId(RESOURCE_PROJECT_ID)
+            .setServiceRpcFactory(mockedRpcFactory)
+            .build();
+    logging = options.getService();
+  }
+
+  @After
+  public void teardown() {
+    (new ContextHandler()).removeCurrentContext();
+  }
+
+  private void mockCurrentContext(HttpRequest request, String traceId, String spanId) {
+    Context mockedContext =
+        Context.newBuilder().setRequest(request).setTraceId(traceId).setSpanId(spanId).build();
+    (new ContextHandler()).setCurrentContext(mockedContext);
+  }
+
+  @Test
+  public void testAutoPopulationEnabledInLoggingOptions() {
+    mockCurrentContext(HTTP_REQUEST, TRACE_ID, SPAN_ID);
+
+    logging.write(ImmutableList.of(SIMPLE_LOG_ENTRY));
+
+    LogEntry actual = LogEntry.fromPb(rpcWriteArgument.getValue().getEntries(0));
+    assertEquals(HTTP_REQUEST, actual.getHttpRequest());
+    assertEquals(FORMATTED_TRACE_ID, actual.getTrace());
+    assertEquals(SPAN_ID, actual.getSpanId());
+    assertEquals(RESOURCE, actual.getResource());
+  }
+
+  @Test
+  public void testAutoPopulationEnabledInWriteOptionsAndDisabledInLoggingOptions() {
+    // redefine logging option to opt out auto-populating
+    LoggingOptions options =
+        logging.getOptions().toBuilder().setAutoPopulateMetadata(false).build();
+    logging = options.getService();
+    mockCurrentContext(HTTP_REQUEST, TRACE_ID, SPAN_ID);
+
+    logging.write(ImmutableList.of(SIMPLE_LOG_ENTRY), WriteOption.autoPopulateMetadata(true));
+
+    LogEntry actual = LogEntry.fromPb(rpcWriteArgument.getValue().getEntries(0));
+    assertEquals(HTTP_REQUEST, actual.getHttpRequest());
+    assertEquals(FORMATTED_TRACE_ID, actual.getTrace());
+    assertEquals(SPAN_ID, actual.getSpanId());
+    assertEquals(RESOURCE, actual.getResource());
+  }
+
+  @Test
+  public void testAutoPopulationDisabledInWriteOptions() {
+    mockCurrentContext(HTTP_REQUEST, TRACE_ID, SPAN_ID);
+
+    logging.write(ImmutableList.of(SIMPLE_LOG_ENTRY), WriteOption.autoPopulateMetadata(false));
+
+    LogEntry actual = LogEntry.fromPb(rpcWriteArgument.getValue().getEntries(0));
+    assertNull(actual.getHttpRequest());
+    assertNull(actual.getTrace());
+    assertNull(actual.getSpanId());
+    assertNull(actual.getResource());
+  }
+
+  @Test
+  public void testSourceLocationPopulation() {
+    SourceLocation expected = SourceLocation.fromCurrentContext(0);
+    logging.write(ImmutableList.of(SIMPLE_LOG_ENTRY_WITH_DEBUG));
+
+    LogEntry actual = LogEntry.fromPb(rpcWriteArgument.getValue().getEntries(0));
+    assertEquals(expected.getFile(), actual.getSourceLocation().getFile());
+    assertEquals(expected.getClass(), actual.getSourceLocation().getClass());
+    assertEquals(expected.getFunction(), actual.getSourceLocation().getFunction());
+    assertEquals(new Long(expected.getLine() + 1), actual.getSourceLocation().getLine());
+  }
+
+  @Test
+  public void testNotFormattedTraceId() {
+    mockCurrentContext(HTTP_REQUEST, TRACE_ID, SPAN_ID);
+
+    final MonitoredResource expectedResource = MonitoredResource.newBuilder("custom").build();
+
+    logging.write(ImmutableList.of(SIMPLE_LOG_ENTRY), WriteOption.resource(expectedResource));
+
+    LogEntry actual = LogEntry.fromPb(rpcWriteArgument.getValue().getEntries(0));
+    assertEquals(TRACE_ID, actual.getTrace());
+  }
+
+  @Test
+  public void testMonitoredResourcePopulationInWriteOptions() {
+    mockCurrentContext(HTTP_REQUEST, TRACE_ID, SPAN_ID);
+
+    final MonitoredResource expectedResource = MonitoredResource.newBuilder("custom").build();
+
+    logging.write(ImmutableList.of(SIMPLE_LOG_ENTRY), WriteOption.resource(expectedResource));
+
+    LogEntry actual = LogEntry.fromPb(rpcWriteArgument.getValue().getEntries(0));
+    assertEquals(expectedResource, actual.getResource());
+  }
+}

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/BaseSystemTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/BaseSystemTest.java
@@ -130,8 +130,6 @@ public class BaseSystemTest {
     return waitForLogs(logName, null, 1);
   }
 
-  private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-
   protected static Iterator<LogEntry> waitForLogs(Logging.EntryListOption[] options, int minLogs)
       throws InterruptedException {
     Page<LogEntry> page = logging.listLogEntries(options);

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -261,6 +261,9 @@ public class LoggingImplTest {
             .setProjectId(PROJECT)
             .setServiceRpcFactory(rpcFactoryMock)
             .setRetrySettings(ServiceOptions.getNoRetrySettings())
+            // disable auto-population for LoggingImpl class tests
+            // see {@see AutoPopulationTests} for auto-population tests
+            .setAutoPopulateMetadata(false)
             .build();
 
     // By default when calling ListLogEntries, we append a filter of last 24 hours.

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingOptionsTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingOptionsTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 public class LoggingOptionsTest {
   private static final Boolean DONT_AUTO_POPULATE_METADATA = false;
+  private static final String PROJECT_ID = "fake-project-id";
 
   @Test(expected = IllegalArgumentException.class)
   public void testNonGrpcTransportOptions() {
@@ -34,13 +35,16 @@ public class LoggingOptionsTest {
   @Test
   public void testAutoPopulateMetadataOption() {
     LoggingOptions actual =
-        LoggingOptions.newBuilder().setAutoPopulateMetadata(DONT_AUTO_POPULATE_METADATA).build();
+        LoggingOptions.newBuilder()
+            .setProjectId(PROJECT_ID)
+            .setAutoPopulateMetadata(DONT_AUTO_POPULATE_METADATA)
+            .build();
     assertEquals(DONT_AUTO_POPULATE_METADATA, actual.getAutoPopulateMetadata());
   }
 
   @Test
   public void testAutoPopulateMetadataDefaultOption() {
-    LoggingOptions actual = LoggingOptions.getDefaultInstance();
+    LoggingOptions actual = LoggingOptions.newBuilder().setProjectId(PROJECT_ID).build();
     assertEquals(Boolean.TRUE, actual.getAutoPopulateMetadata());
   }
 }

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingOptionsTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingOptionsTest.java
@@ -16,21 +16,31 @@
 
 package com.google.cloud.logging;
 
+import static org.easymock.EasyMock.createMock;
+import static org.junit.Assert.assertEquals;
+
 import com.google.cloud.TransportOptions;
-import org.easymock.EasyMock;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class LoggingOptionsTest {
+  private static final Boolean DONT_AUTO_POPULATE_METADATA = false;
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNonGrpcTransportOptions() {
+    TransportOptions invalidTransport = createMock(TransportOptions.class);
+    LoggingOptions.newBuilder().setTransportOptions(invalidTransport);
+  }
 
   @Test
-  public void testInvalidTransport() {
-    try {
-      LoggingOptions.newBuilder()
-          .setTransportOptions(EasyMock.<TransportOptions>createMock(TransportOptions.class));
-      Assert.fail();
-    } catch (IllegalArgumentException expected) {
-      Assert.assertNotNull(expected.getMessage());
-    }
+  public void testAutoPopulateMetadataOption() {
+    LoggingOptions actual =
+        LoggingOptions.newBuilder().setAutoPopulateMetadata(DONT_AUTO_POPULATE_METADATA).build();
+    assertEquals(DONT_AUTO_POPULATE_METADATA, actual.getAutoPopulateMetadata());
+  }
+
+  @Test
+  public void testAutoPopulateMetadataDefaultOption() {
+    LoggingOptions actual = LoggingOptions.getDefaultInstance();
+    assertEquals(Boolean.TRUE, actual.getAutoPopulateMetadata());
   }
 }

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingTest.java
@@ -43,6 +43,7 @@ public class LoggingTest {
   private static final String FOLDER_NAME = "folder";
   private static final String ORGANIZATION_NAME = "organization";
   private static final String BILLING_NAME = "billing";
+  private static final Boolean DONT_AUTO_POPULATE_METADATA = false;
 
   @Test
   public void testListOption() {
@@ -109,6 +110,10 @@ public class LoggingTest {
     writeOption = WriteOption.resource(RESOURCE);
     assertEquals(RESOURCE, writeOption.getValue());
     assertEquals(WriteOption.OptionType.RESOURCE, writeOption.getOptionType());
+
+    writeOption = WriteOption.autoPopulateMetadata(DONT_AUTO_POPULATE_METADATA);
+    assertEquals(DONT_AUTO_POPULATE_METADATA, writeOption.getValue());
+    assertEquals(WriteOption.OptionType.AUTO_POPULATE_METADATA, writeOption.getOptionType());
   }
 
   @Test

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/SourceLocationTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/SourceLocationTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.logging;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
@@ -61,22 +62,39 @@ public class SourceLocationTest {
   @Test
   public void testFromCurrentContext() {
     StackTraceElement expectedData = (new Exception()).getStackTrace()[0];
-    SourceLocation data = SourceLocation.fromCurrentContext(0);
+    SourceLocation data = SourceLocation.fromCurrentContext();
     assertEquals(expectedData.getFileName(), data.getFile());
     assertEquals(expectedData.getMethodName(), data.getFunction());
-    // mind the assertion is vs (expectedData.lineNumber + 1). it is because the source location
-    // info of the expectedData is one line above the source location of the tested data.
+    // mind the assertion is vs (expectedData.lineNumber + 1). it is because the
+    // source location
+    // info of the expectedData is one line above the source location of the tested
+    // data.
     assertEquals(Long.valueOf(expectedData.getLineNumber() + 1), data.getLine());
   }
 
-  @Test(expected = IndexOutOfBoundsException.class)
-  public void testFromCurrentContextWithNegativeLevel() {
-    SourceLocation.fromCurrentContext(-1);
+  @Test
+  public void testFromCurrentContextWithExclusionList() {
+    StackTraceElement expectedData = (new Exception()).getStackTrace()[0];
+    SourceLocation data = SourceLocation.fromCurrentContext(LoggingImpl.class.getName());
+    assertEquals(expectedData.getFileName(), data.getFile());
+    assertEquals(expectedData.getMethodName(), data.getFunction());
+    // mind the assertion is vs (expectedData.lineNumber + 1). it is because the
+    // source location
+    // info of the expectedData is one line above the source location of the tested
+    // data.
+    assertEquals(Long.valueOf(expectedData.getLineNumber() + 1), data.getLine());
   }
 
-  @Test(expected = IndexOutOfBoundsException.class)
+  public void testFromCurrentContextWithNegativeLevel() {
+    SourceLocation data = SourceLocation.fromCurrentContext((String[]) null);
+    assertNull(data);
+  }
+
+  @Test
   public void testFromCurrentContextWithVeryLargeLevel() {
-    SourceLocation.fromCurrentContext(10000);
+    SourceLocation data =
+        SourceLocation.fromCurrentContext("com.google", "sun", "java", "jdk", "org");
+    assertNull(data);
   }
 
   private void compareSourceLocation(SourceLocation expected, SourceLocation value) {


### PR DESCRIPTION
PR aggregates the following changes:

- https://github.com/googleapis/java-logging/pull/821
- https://github.com/googleapis/java-logging/pull/812
- https://github.com/googleapis/java-logging/pull/807
- https://github.com/googleapis/java-logging/pull/803
- https://github.com/googleapis/java-logging/pull/798

Fixes #689, closes #691, closes #799 and resolves #800
