### PR TITLE
feat: ingest structured logs using stdout in LoggingHandler

### DIFF
--- a/google-cloud-logging/clirr-ignored-differences.xml
+++ b/google-cloud-logging/clirr-ignored-differences.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/logging/Logging</className>
+    <method>java.lang.Iterable populateMetadata(java.lang.Iterable, com.google.cloud.MonitoredResource, java.lang.String[])</method>
+  </difference>
+</differences>

--- a/google-cloud-logging/pom.xml
+++ b/google-cloud-logging/pom.xml
@@ -22,6 +22,11 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.9</version>
+    </dependency>
+    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
     </dependency>

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
@@ -19,9 +19,17 @@ package com.google.cloud.logging;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.cloud.MonitoredResource;
+import com.google.cloud.logging.Payload.Type;
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 import com.google.logging.v2.LogEntryOperation;
 import com.google.logging.v2.LogEntrySourceLocation;
 import com.google.logging.v2.LogName;
@@ -61,8 +69,8 @@ public class LogEntry implements Serializable {
   private final HttpRequest httpRequest;
   private final Map<String, String> labels;
   private final Operation operation;
-  private final Object trace;
-  private final Object spanId;
+  private final String trace;
+  private final String spanId;
   private final boolean traceSampled;
   private final SourceLocation sourceLocation;
   private final Payload<?> payload;
@@ -80,8 +88,8 @@ public class LogEntry implements Serializable {
     private HttpRequest httpRequest;
     private Map<String, String> labels = new HashMap<>();
     private Operation operation;
-    private Object trace;
-    private Object spanId;
+    private String trace;
+    private String spanId;
     private boolean traceSampled;
     private SourceLocation sourceLocation;
     private Payload<?> payload;
@@ -245,7 +253,7 @@ public class LogEntry implements Serializable {
      * relative resource name, the name is assumed to be relative to `//tracing.googleapis.com`.
      */
     public Builder setTrace(Object trace) {
-      this.trace = trace;
+      this.trace = trace != null ? trace.toString() : null;
       return this;
     }
 
@@ -257,7 +265,7 @@ public class LogEntry implements Serializable {
 
     /** Sets the ID of the trace span associated with the log entry, if any. */
     public Builder setSpanId(Object spanId) {
-      this.spanId = spanId;
+      this.spanId = spanId != null ? spanId.toString() : null;
       return this;
     }
 
@@ -573,6 +581,145 @@ public class LogEntry implements Serializable {
       builder.setSourceLocation(sourceLocation.toPb());
     }
     return builder.build();
+  }
+
+  /**
+   * Customized serializers to match the expected format for timestamp, source location and request
+   * method
+   */
+  static final class InstantSerializer implements JsonSerializer<Instant> {
+    @Override
+    public JsonElement serialize(
+        Instant src, java.lang.reflect.Type typeOfSrc, JsonSerializationContext context) {
+      return new JsonPrimitive(src.toString());
+    }
+  }
+
+  static final class SourceLocationSerializer implements JsonSerializer<SourceLocation> {
+    @Override
+    public JsonElement serialize(
+        SourceLocation src, java.lang.reflect.Type typeOfSrc, JsonSerializationContext context) {
+      JsonObject obj = new JsonObject();
+      if (src.getFile() != null) {
+        obj.addProperty("file", src.getFile());
+      }
+      if (src.getLine() != null) {
+        obj.addProperty("line", src.getLine().toString());
+      }
+      if (src.getFunction() != null) {
+        obj.addProperty("function", src.getFunction());
+      }
+      return obj;
+    }
+  }
+
+  static final class RequestMethodSerializer implements JsonSerializer<HttpRequest.RequestMethod> {
+    @Override
+    public JsonElement serialize(
+        HttpRequest.RequestMethod src,
+        java.lang.reflect.Type typeOfSrc,
+        JsonSerializationContext context) {
+      return new JsonPrimitive(src.name());
+    }
+  }
+
+  /** Helper class to format one line Json representation of the LogEntry for structured log. */
+  static final class StructuredLogFormatter {
+    private final Gson gson;
+    private final StringBuilder builder;
+
+    public StructuredLogFormatter(StringBuilder builder) {
+      checkNotNull(builder);
+      this.gson =
+          new GsonBuilder()
+              .registerTypeAdapter(Instant.class, new InstantSerializer())
+              .registerTypeAdapter(SourceLocation.class, new SourceLocationSerializer())
+              .registerTypeAdapter(HttpRequest.RequestMethod.class, new RequestMethodSerializer())
+              .create();
+      this.builder = builder;
+    }
+
+    /**
+     * Adds a Json field and value pair to the current string representation. Method does not
+     * validate parameters to be multi-line strings. Nothing is added if {@code value} parameter is
+     * {@code null}.
+     *
+     * @param name a valid Json field name string.
+     * @param value an object to be serialized to Json using {@link Gson}.
+     * @param appendComma a flag to add a trailing comma.
+     * @return a reference to this object.
+     */
+    public StructuredLogFormatter appendField(String name, Object value, boolean appendComma) {
+      checkNotNull(name);
+      if (value != null) {
+        builder.append(gson.toJson(name)).append(":").append(gson.toJson(value));
+        if (!appendComma) {
+          builder.append(",");
+        }
+      }
+      return this;
+    }
+
+    public StructuredLogFormatter appendField(String name, Object value) {
+      return appendField(name, value, false);
+    }
+
+    /**
+     * Adds a collection of Json fields that {@code value} parameter is serialized to to the current
+     * string representation. Nothing is added if {@code value} parameter is {@code null}.
+     *
+     * @param value an object to be serialized to Json using {@link Gson}.
+     * @param appendComma a flag to add a trailing comma.
+     * @return a reference to this object.
+     */
+    public StructuredLogFormatter appendJson(Object value, boolean appendComma) {
+      if (value != null) {
+        String json = gson.toJson(value);
+        // append json object without brackets
+        if (json.length() > 1) {
+          builder.append(json.substring(0, json.length() - 1).substring(1));
+          if (!appendComma) {
+            builder.append(",");
+          }
+        }
+      }
+      return this;
+    }
+
+    public StructuredLogFormatter appendJson(Object value) {
+      return appendJson(value, false);
+    }
+  }
+
+  /**
+   * Serializes the object to a one line JSON string in the simplified format that can be parsed by
+   * the logging agents that run on Google Cloud resources.
+   */
+  public String toStructuredJsonString() {
+    final StringBuilder builder = new StringBuilder("{");
+    final StructuredLogFormatter formatter = new StructuredLogFormatter(builder);
+
+    formatter
+        .appendField("severity", severity)
+        .appendField("timestamp", timestamp)
+        .appendField("httpRequest", httpRequest)
+        .appendField("logging.googleapis.com/insertId", insertId)
+        .appendField("logging.googleapis.com/labels", labels)
+        .appendField("logging.googleapis.com/operation", operation)
+        .appendField("logging.googleapis.com/sourceLocation", sourceLocation)
+        .appendField("logging.googleapis.com/spanId", spanId)
+        .appendField("logging.googleapis.com/trace", trace)
+        .appendField("logging.googleapis.com/trace_sampled", traceSampled);
+    if (payload.getType() == Type.STRING) {
+      formatter.appendField("message", payload.getData(), true);
+    } else if (payload.getType() == Type.JSON) {
+      Payload.JsonPayload jsonPayload = (Payload.JsonPayload) payload;
+      formatter.appendJson(jsonPayload.getDataAsMap(), true);
+    } else if (payload.getType() == Type.PROTO) {
+      throw new UnsupportedOperationException("LogEntry with protobuf payload cannot be converted");
+    }
+    builder.append("}");
+    return builder.toString();
   }
 
   /** Returns a builder for {@code LogEntry} objects given the entry payload. */

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
@@ -665,14 +665,13 @@ public class LogEntry implements Serializable {
     }
 
     /**
-     * Adds a collection of Json fields that {@code value} parameter is serialized to to the current
-     * string representation. Nothing is added if {@code value} parameter is {@code null}.
+     * Serializes a dictionary of key, values as Json fields.
      *
-     * @param value an object to be serialized to Json using {@link Gson}.
+     * @param value a {@link Map} of key, value arguments to be serialized using {@link Gson}.
      * @param appendComma a flag to add a trailing comma.
      * @return a reference to this object.
      */
-    public StructuredLogFormatter appendJson(Object value, boolean appendComma) {
+    public StructuredLogFormatter appendDict(Map<String, Object> value, boolean appendComma) {
       if (value != null) {
         String json = gson.toJson(value);
         // append json object without brackets
@@ -685,10 +684,6 @@ public class LogEntry implements Serializable {
       }
       return this;
     }
-
-    public StructuredLogFormatter appendJson(Object value) {
-      return appendJson(value, false);
-    }
   }
 
   /**
@@ -696,6 +691,10 @@ public class LogEntry implements Serializable {
    * the logging agents that run on Google Cloud resources.
    */
   public String toStructuredJsonString() {
+    if (payload.getType() == Type.PROTO) {
+      throw new UnsupportedOperationException("LogEntry with protobuf payload cannot be converted");
+    }
+
     final StringBuilder builder = new StringBuilder("{");
     final StructuredLogFormatter formatter = new StructuredLogFormatter(builder);
 
@@ -714,9 +713,7 @@ public class LogEntry implements Serializable {
       formatter.appendField("message", payload.getData(), true);
     } else if (payload.getType() == Type.JSON) {
       Payload.JsonPayload jsonPayload = (Payload.JsonPayload) payload;
-      formatter.appendJson(jsonPayload.getDataAsMap(), true);
-    } else if (payload.getType() == Type.PROTO) {
-      throw new UnsupportedOperationException("LogEntry with protobuf payload cannot be converted");
+      formatter.appendDict(jsonPayload.getDataAsMap(), true);
     }
     builder.append("}");
     return builder.toString();

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
@@ -1286,8 +1286,30 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
    * </pre>
    */
   @BetaApi("The surface for the tail streaming is not stable yet and may change in the future.")
-  default LogEntryServerStream tailLogEntries(TailOption... options) {
+  LogEntryServerStream tailLogEntries(TailOption... options);
+
+  /**
+   * Populates metadata fields of the immutable collection of {@link LogEntry} items. Only empty
+   * fields are populated. The {@link SourceLocation} is populated only for items with the severity
+   * set to {@link Severity.DEBUG}. The information about {@link HttpRequest}, trace and span Id is
+   * retrieved using {@link ContextHandler}.
+   *
+   * @param logEntries an immutable collection of {@link LogEntry} items.
+   * @param customResource a customized instance of the {@link MonitoredResource}. If this parameter
+   *     is {@code null} then the new instance will be generated using {@link
+   *     MonitoredResourceUtil#getResource(String, String)}.
+   * @param exclusionClassPaths a list of exclussion class path prefixes. If left empty then {@link
+   *     SourceLocation} instance is built based on the caller's stack trace information. Otherwise,
+   *     the information from the first {@link StackTraceElement} along the call stack which class
+   *     name does not start with any not {@code null} exclusion class paths is used.
+   * @return A collection of {@link LogEntry} items composed from the {@code logEntries} parameter
+   *     with populated metadata fields.
+   */
+  default Iterable<LogEntry> populateMetadata(
+      Iterable<LogEntry> logEntries,
+      MonitoredResource customResource,
+      String... exclusionClassPaths) {
     throw new UnsupportedOperationException(
-        "method tailLogEntriesCallable() does not have default implementation");
+        "method populateMetadata() does not have default implementation");
   }
 }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingConfig.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingConfig.java
@@ -42,7 +42,7 @@ class LoggingConfig {
   private static final String ENHANCERS_TAG = "enhancers";
   private static final String USE_INHERITED_CONTEXT = "useInheritedContext";
   private static final String AUTO_POPULATE_METADATA = "autoPopulateMetadata";
-  private static final String USE_STRUCTURED_LOGGING = "useStructuredLogging";
+  private static final String REDIRECT_TO_STDOUT = "redirectToStdout";
 
   public LoggingConfig(String className) {
     this.className = className;
@@ -82,8 +82,8 @@ class LoggingConfig {
     return getBooleanProperty(AUTO_POPULATE_METADATA, null);
   }
 
-  Boolean getUseStructuredLogging() {
-    return getBooleanProperty(USE_STRUCTURED_LOGGING, null);
+  Boolean getRedirectToStdout() {
+    return getBooleanProperty(REDIRECT_TO_STDOUT, null);
   }
 
   MonitoredResource getMonitoredResource(String projectId) {

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingConfig.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingConfig.java
@@ -42,6 +42,7 @@ class LoggingConfig {
   private static final String ENHANCERS_TAG = "enhancers";
   private static final String USE_INHERITED_CONTEXT = "useInheritedContext";
   private static final String AUTO_POPULATE_METADATA = "autoPopulateMetadata";
+  private static final String USE_STRUCTURED_LOGGING = "useStructuredLogging";
 
   public LoggingConfig(String className) {
     this.className = className;
@@ -78,11 +79,11 @@ class LoggingConfig {
   }
 
   Boolean getAutoPopulateMetadata() {
-    String flag = getProperty(AUTO_POPULATE_METADATA);
-    if (flag != null) {
-      return Boolean.parseBoolean(flag);
-    }
-    return null;
+    return getBooleanProperty(AUTO_POPULATE_METADATA, null);
+  }
+
+  Boolean getUseStructuredLogging() {
+    return getBooleanProperty(USE_STRUCTURED_LOGGING, null);
   }
 
   MonitoredResource getMonitoredResource(String projectId) {
@@ -125,6 +126,14 @@ class LoggingConfig {
 
   private String getProperty(String name, String defaultValue) {
     return firstNonNull(getProperty(name), defaultValue);
+  }
+
+  private Boolean getBooleanProperty(String name, Boolean defaultValue) {
+    String flag = getProperty(name);
+    if (flag != null) {
+      return Boolean.parseBoolean(flag);
+    }
+    return defaultValue;
   }
 
   private Level getLevelProperty(String name, Level defaultValue) {

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/SourceLocation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/SourceLocation.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.logging;
 
+import com.google.api.client.util.Strings;
 import com.google.common.base.MoreObjects;
 import com.google.logging.v2.LogEntrySourceLocation;
 import java.io.Serializable;
@@ -175,7 +176,7 @@ public final class SourceLocation implements Serializable {
       String className = ste.getClassName();
 
       if (exclusionClassPaths != null) {
-        if (Arrays.stream(exclusionClassPaths).anyMatch(prefix -> className.startsWith(prefix))) {
+        if (Strings.isNullOrEmpty(className) || Arrays.stream(exclusionClassPaths).anyMatch(prefix -> prefix != null && className.startsWith(prefix))) {
           continue;
         }
       }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/SourceLocation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/SourceLocation.java
@@ -171,15 +171,21 @@ public final class SourceLocation implements Serializable {
   static SourceLocation fromCurrentContext(String... exclusionClassPaths) {
     StackTraceElement[] stackTrace = (new Exception()).getStackTrace();
 
+    if (exclusionClassPaths != null) {
+      System.out.println("DEBUG: list of exclusions: " + String.join(", ", exclusionClassPaths));
+    }
     for (int level = 1; level < stackTrace.length; level++) {
       StackTraceElement ste = stackTrace[level];
       String className = ste.getClassName();
 
       if (exclusionClassPaths != null) {
-        if (Strings.isNullOrEmpty(className) || Arrays.stream(exclusionClassPaths).anyMatch(prefix -> prefix != null && className.startsWith(prefix))) {
+        if (Strings.isNullOrEmpty(className)
+            || Arrays.stream(exclusionClassPaths)
+                .anyMatch(prefix -> prefix != null && className.startsWith(prefix))) {
           continue;
         }
       }
+      System.out.println("DEBUG: selected element class nName: '" + className + "'");
       return newBuilder()
           .setFile(ste.getFileName())
           .setLine(Long.valueOf(ste.getLineNumber()))

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/SourceLocation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/SourceLocation.java
@@ -171,9 +171,6 @@ public final class SourceLocation implements Serializable {
   static SourceLocation fromCurrentContext(String... exclusionClassPaths) {
     StackTraceElement[] stackTrace = (new Exception()).getStackTrace();
 
-    if (exclusionClassPaths != null) {
-      System.out.println("DEBUG: list of exclusions: " + String.join(", ", exclusionClassPaths));
-    }
     for (int level = 1; level < stackTrace.length; level++) {
       StackTraceElement ste = stackTrace[level];
       String className = ste.getClassName();
@@ -185,7 +182,6 @@ public final class SourceLocation implements Serializable {
           continue;
         }
       }
-      System.out.println("DEBUG: selected element class nName: '" + className + "'");
       return newBuilder()
           .setFile(ste.getFileName())
           .setLine(Long.valueOf(ste.getLineNumber()))

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/SourceLocation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/SourceLocation.java
@@ -16,11 +16,10 @@
 
 package com.google.cloud.logging;
 
-import static com.google.common.base.Preconditions.checkElementIndex;
-
 import com.google.common.base.MoreObjects;
 import com.google.logging.v2.LogEntrySourceLocation;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Objects;
 
 /** Additional information about the source code location that produced the log entry. */
@@ -158,28 +157,34 @@ public final class SourceLocation implements Serializable {
   }
 
   /**
-   * Creates instance of {@link SourceLocation} based on stack trace information. Caller should
-   * provide the level in the stack where the information can be located. The stack trace level
-   * should be {@code 0} to display information for the caller of the method.
+   * Creates an instance of {@link SourceLocation} based on stack trace information. The stack trace
+   * level is determined based on the exclusion list of the class paths provided in the {@code
+   * exclusionClassPaths} parameter. If the list is empty or not defined the caller's stack trace
+   * information is used. Otherwise, the first {@link StackTraceElement} along the stack which class
+   * name does not start with any not {@code null} exclusion class paths will be used.
    *
-   * @param level Zero-based non-negative integer defining the level in the stack trace where {@code
-   *     0} is topmost element.
+   * @param exclusionClassPaths a varargs array of strings containing class path prefixes.
    * @return a new instance of {@link SourceLocation} populated with file name, method and line
    *     number information.
-   * @throws IndexOutOfBoundsException if the provided {@link level} is negative or greater than the
-   *     current call stack.
    */
-  static SourceLocation fromCurrentContext(int level) {
+  static SourceLocation fromCurrentContext(String... exclusionClassPaths) {
     StackTraceElement[] stackTrace = (new Exception()).getStackTrace();
-    Builder builder = newBuilder();
-    // need to take info from 1 level down the stack to compensate the call to this
-    // method
-    int indexPlus = checkElementIndex(level, stackTrace.length - 1) + 1;
-    StackTraceElement ste = stackTrace[indexPlus];
-    return builder
-        .setFile(ste.getFileName())
-        .setLine(Long.valueOf(ste.getLineNumber()))
-        .setFunction(ste.getMethodName())
-        .build();
+
+    for (int level = 1; level < stackTrace.length; level++) {
+      StackTraceElement ste = stackTrace[level];
+      String className = ste.getClassName();
+
+      if (exclusionClassPaths != null) {
+        if (Arrays.stream(exclusionClassPaths).anyMatch(prefix -> className.startsWith(prefix))) {
+          continue;
+        }
+      }
+      return newBuilder()
+          .setFile(ste.getFileName())
+          .setLine(Long.valueOf(ste.getLineNumber()))
+          .setFunction(ste.getMethodName())
+          .build();
+    }
+    return null;
   }
 }

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/AutoPopulateMetadataTests.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/AutoPopulateMetadataTests.java
@@ -89,7 +89,8 @@ public class AutoPopulateMetadataTests {
     expect(mockedRpc.write(capture(rpcWriteArgument)))
         .andReturn(ApiFutures.immediateFuture(EMPTY_WRITE_RESPONSE));
     MonitoredResourceUtil.setEnvironmentGetter(mockedEnvGetter);
-    // the following mocks generate MonitoredResource instance same as RESOURCE constant
+    // the following mocks generate MonitoredResource instance same as RESOURCE
+    // constant
     expect(mockedEnvGetter.getAttribute("project/project-id")).andStubReturn(RESOURCE_PROJECT_ID);
     expect(mockedEnvGetter.getAttribute("")).andStubReturn(null);
     replay(mockedRpcFactory, mockedRpc, mockedEnvGetter);
@@ -158,7 +159,7 @@ public class AutoPopulateMetadataTests {
 
   @Test
   public void testSourceLocationPopulation() {
-    SourceLocation expected = SourceLocation.fromCurrentContext(0);
+    SourceLocation expected = SourceLocation.fromCurrentContext();
     logging.write(ImmutableList.of(SIMPLE_LOG_ENTRY_WITH_DEBUG));
 
     LogEntry actual = LogEntry.fromPb(rpcWriteArgument.getValue().getEntries(0));

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
@@ -21,13 +21,17 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertTrue;
 
+import com.google.api.client.util.Strings;
 import com.google.cloud.MonitoredResource;
 import com.google.cloud.logging.LogEntry.Builder;
 import com.google.cloud.logging.Logging.WriteOption;
 import com.google.cloud.logging.Payload.StringPayload;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.Collections;
 import java.util.logging.ErrorManager;
 import java.util.logging.Filter;
@@ -199,6 +203,10 @@ public class LoggingHandlerTest {
     expect(options.getProjectId()).andStubReturn(PROJECT);
     expect(options.getService()).andStubReturn(logging);
     expect(options.getAutoPopulateMetadata()).andStubReturn(Boolean.FALSE);
+    logging.setFlushSeverity(EasyMock.anyObject(Severity.class));
+    expectLastCall().once();
+    logging.setWriteSynchronicity(EasyMock.anyObject(Synchronicity.class));
+    expectLastCall().once();
   }
 
   @After
@@ -214,10 +222,6 @@ public class LoggingHandlerTest {
 
   @Test
   public void testPublishLevels() {
-    logging.setFlushSeverity(Severity.ERROR);
-    expectLastCall().once();
-    logging.setWriteSynchronicity(Synchronicity.ASYNC);
-    expectLastCall().once();
     logging.write(ImmutableList.of(FINEST_ENTRY), DEFAULT_OPTIONS);
     expectLastCall().once();
     logging.write(ImmutableList.of(FINER_ENTRY), DEFAULT_OPTIONS);
@@ -267,10 +271,6 @@ public class LoggingHandlerTest {
 
   @Test
   public void testPublishCustomResource() {
-    logging.setFlushSeverity(Severity.ERROR);
-    expectLastCall().once();
-    logging.setWriteSynchronicity(Synchronicity.ASYNC);
-    expectLastCall().once();
     MonitoredResource resource = MonitoredResource.of("custom", ImmutableMap.<String, String>of());
     logging.write(
         ImmutableList.of(FINEST_ENTRY),
@@ -309,10 +309,6 @@ public class LoggingHandlerTest {
 
   @Test
   public void testPublishKubernetesContainerResource() {
-    logging.setFlushSeverity(Severity.ERROR);
-    expectLastCall().once();
-    logging.setWriteSynchronicity(Synchronicity.ASYNC);
-    expectLastCall().once();
     MonitoredResource resource =
         MonitoredResource.of(
             "k8s_container",
@@ -342,10 +338,6 @@ public class LoggingHandlerTest {
 
   @Test
   public void testEnhancedLogEntry() {
-    logging.setFlushSeverity(Severity.ERROR);
-    expectLastCall().once();
-    logging.setWriteSynchronicity(Synchronicity.ASYNC);
-    expectLastCall().once();
     logging.write(ImmutableList.of(FINEST_ENHANCED_ENTRY), DEFAULT_OPTIONS);
     expectLastCall().once();
     replay(options, logging);
@@ -366,10 +358,6 @@ public class LoggingHandlerTest {
 
   @Test
   public void testTraceEnhancedLogEntry() {
-    logging.setFlushSeverity(Severity.ERROR);
-    expectLastCall().once();
-    logging.setWriteSynchronicity(Synchronicity.ASYNC);
-    expectLastCall().once();
     logging.write(ImmutableList.of(TRACE_ENTRY), DEFAULT_OPTIONS);
     expectLastCall().once();
     replay(options, logging);
@@ -386,10 +374,6 @@ public class LoggingHandlerTest {
   @Test
   public void testReportWriteError() {
     RuntimeException ex = new RuntimeException();
-    logging.setFlushSeverity(Severity.ERROR);
-    expectLastCall().once();
-    logging.setWriteSynchronicity(Synchronicity.ASYNC);
-    expectLastCall().once();
     logging.write(ImmutableList.of(FINEST_ENTRY), DEFAULT_OPTIONS);
     expectLastCall().andStubThrow(ex);
     replay(options, logging);
@@ -408,10 +392,6 @@ public class LoggingHandlerTest {
   @Test
   public void testReportFlushError() {
     RuntimeException ex = new RuntimeException();
-    logging.setFlushSeverity(Severity.ERROR);
-    expectLastCall().once();
-    logging.setWriteSynchronicity(Synchronicity.ASYNC);
-    expectLastCall().once();
     logging.write(ImmutableList.of(FINEST_ENTRY), DEFAULT_OPTIONS);
     expectLastCall().once();
     logging.flush();
@@ -432,10 +412,6 @@ public class LoggingHandlerTest {
 
   @Test
   public void testReportFormatError() {
-    logging.setFlushSeverity(Severity.ERROR);
-    expectLastCall().once();
-    logging.setWriteSynchronicity(Synchronicity.ASYNC);
-    expectLastCall().once();
     replay(options, logging);
     Formatter formatter = EasyMock.createStrictMock(Formatter.class);
     RuntimeException ex = new RuntimeException();
@@ -456,10 +432,6 @@ public class LoggingHandlerTest {
   // BUG(1795): rewrite this test when flush actually works.
   // @Test
   public void testFlushLevel() {
-    logging.setFlushSeverity(Severity.ERROR);
-    expectLastCall().once();
-    logging.setWriteSynchronicity(Synchronicity.ASYNC);
-    expectLastCall().once();
     logging.setFlushSeverity(Severity.WARNING);
     expectLastCall().once();
     logging.write(
@@ -490,10 +462,6 @@ public class LoggingHandlerTest {
             .setTimestamp(123456789L)
             .build();
 
-    logging.setFlushSeverity(Severity.ERROR);
-    expectLastCall().once();
-    logging.setWriteSynchronicity(Synchronicity.ASYNC);
-    expectLastCall().once();
     logging.setWriteSynchronicity(Synchronicity.SYNC);
     expectLastCall().once();
     logging.write(ImmutableList.of(entry), DEFAULT_OPTIONS);
@@ -511,10 +479,6 @@ public class LoggingHandlerTest {
 
   @Test
   public void testAddHandler() {
-    logging.setFlushSeverity(Severity.ERROR);
-    expectLastCall().once();
-    logging.setWriteSynchronicity(Synchronicity.ASYNC);
-    expectLastCall().andVoid();
     logging.write(ImmutableList.of(FINEST_ENTRY), DEFAULT_OPTIONS);
     expectLastCall().once();
     replay(options, logging);
@@ -535,10 +499,6 @@ public class LoggingHandlerTest {
 
   @Test
   public void testClose() throws Exception {
-    logging.setFlushSeverity(Severity.ERROR);
-    expectLastCall().once();
-    logging.setWriteSynchronicity(Synchronicity.ASYNC);
-    expectLastCall().once();
     logging.write(ImmutableList.of(FINEST_ENTRY), DEFAULT_OPTIONS);
     expectLastCall().once();
     logging.close();
@@ -551,17 +511,17 @@ public class LoggingHandlerTest {
     handler.close();
   }
 
-  @Test
-  public void testAutoPopulationEnabled() {
+  private void setupOptionsToEnableAutoPopulation() {
     reset(options);
     options = EasyMock.createMock(LoggingOptions.class);
     expect(options.getProjectId()).andStubReturn(PROJECT);
     expect(options.getService()).andStubReturn(logging);
     expect(options.getAutoPopulateMetadata()).andStubReturn(Boolean.TRUE);
-    logging.setFlushSeverity(EasyMock.anyObject(Severity.class));
-    expectLastCall().once();
-    logging.setWriteSynchronicity(EasyMock.anyObject(Synchronicity.class));
-    expectLastCall().once();
+  }
+
+  @Test
+  public void testAutoPopulationEnabled() {
+    setupOptionsToEnableAutoPopulation();
     // due to the EasyMock bug https://github.com/easymock/easymock/issues/130
     // it is impossible to define expectation for varargs using anyObject() matcher
     // the following mock uses the known fact that the method pass two exclusion prefixes
@@ -584,12 +544,47 @@ public class LoggingHandlerTest {
     handler.publish(newLogRecord(Level.INFO, MESSAGE));
   }
 
+  @Test
+  public void testStructuredLoggingEnabled() {
+    setupOptionsToEnableAutoPopulation();
+    expect(
+            logging.populateMetadata(
+                EasyMock.eq(ImmutableList.of(INFO_ENTRY)),
+                EasyMock.eq(DEFAULT_RESOURCE),
+                EasyMock.anyString(),
+                EasyMock.anyString()))
+        .andReturn(ImmutableList.of(INFO_ENTRY))
+        .once();
+    replay(options, logging);
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    PrintStream out = new PrintStream(bout);
+    System.setOut(out);
+
+    LoggingHandler handler = new LoggingHandler(LOG_NAME, options, DEFAULT_RESOURCE);
+    handler.setLevel(Level.ALL);
+    handler.setFormatter(new TestFormatter());
+    handler.setUseStructuredLogging(true);
+    handler.publish(newLogRecord(Level.INFO, MESSAGE));
+
+    assertTrue(null, !Strings.isNullOrEmpty(bout.toString()));
+    System.setOut(null);
+  }
+
+  @Test
+  /** Validate that nothing is printed to STDOUT */
+  public void testStructuredLoggingDisabled() {
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    PrintStream out = new PrintStream(bout);
+    System.setOut(out);
+
+    testAutoPopulationEnabled();
+
+    assertTrue(null, Strings.isNullOrEmpty(bout.toString()));
+    System.setOut(null);
+  }
+
   private void testPublishCustomResourceWithDestination(
       LogEntry entry, LogDestinationName destination) {
-    logging.setFlushSeverity(Severity.ERROR);
-    expectLastCall().once();
-    logging.setWriteSynchronicity(Synchronicity.ASYNC);
-    expectLastCall().once();
     MonitoredResource resource = MonitoredResource.of("custom", ImmutableMap.<String, String>of());
     logging.write(
         ImmutableList.of(entry),

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
@@ -563,7 +563,7 @@ public class LoggingHandlerTest {
     LoggingHandler handler = new LoggingHandler(LOG_NAME, options, DEFAULT_RESOURCE);
     handler.setLevel(Level.ALL);
     handler.setFormatter(new TestFormatter());
-    handler.setUseStructuredLogging(true);
+    handler.setRedirectToStdout(true);
     handler.publish(newLogRecord(Level.INFO, MESSAGE));
 
     assertTrue(null, !Strings.isNullOrEmpty(bout.toString()));

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/SourceLocationTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/SourceLocationTest.java
@@ -92,7 +92,8 @@ public class SourceLocationTest {
 
   @Test
   public void testFromCurrentContextWithVeryLargeLevel() {
-    SourceLocation data = SourceLocation.fromCurrentContext("com.google", "sun", "java", "jdk", "org");
+    SourceLocation data =
+        SourceLocation.fromCurrentContext("com.google", "sun", "java", "jdk", "org");
     assertNull(data);
   }
 

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/SourceLocationTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/SourceLocationTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.logging;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
@@ -61,22 +62,38 @@ public class SourceLocationTest {
   @Test
   public void testFromCurrentContext() {
     StackTraceElement expectedData = (new Exception()).getStackTrace()[0];
-    SourceLocation data = SourceLocation.fromCurrentContext(0);
+    SourceLocation data = SourceLocation.fromCurrentContext();
     assertEquals(expectedData.getFileName(), data.getFile());
     assertEquals(expectedData.getMethodName(), data.getFunction());
-    // mind the assertion is vs (expectedData.lineNumber + 1). it is because the source location
-    // info of the expectedData is one line above the source location of the tested data.
+    // mind the assertion is vs (expectedData.lineNumber + 1). it is because the
+    // source location
+    // info of the expectedData is one line above the source location of the tested
+    // data.
     assertEquals(Long.valueOf(expectedData.getLineNumber() + 1), data.getLine());
   }
 
-  @Test(expected = IndexOutOfBoundsException.class)
-  public void testFromCurrentContextWithNegativeLevel() {
-    SourceLocation.fromCurrentContext(-1);
+  @Test
+  public void testFromCurrentContextWithExclusionList() {
+    StackTraceElement expectedData = (new Exception()).getStackTrace()[0];
+    SourceLocation data = SourceLocation.fromCurrentContext(LoggingImpl.class.getName());
+    assertEquals(expectedData.getFileName(), data.getFile());
+    assertEquals(expectedData.getMethodName(), data.getFunction());
+    // mind the assertion is vs (expectedData.lineNumber + 1). it is because the
+    // source location
+    // info of the expectedData is one line above the source location of the tested
+    // data.
+    assertEquals(Long.valueOf(expectedData.getLineNumber() + 1), data.getLine());
   }
 
-  @Test(expected = IndexOutOfBoundsException.class)
+  public void testFromCurrentContextWithNegativeLevel() {
+    SourceLocation data = SourceLocation.fromCurrentContext((String[]) null);
+    assertNull(data);
+  }
+
+  @Test
   public void testFromCurrentContextWithVeryLargeLevel() {
-    SourceLocation.fromCurrentContext(10000);
+    SourceLocation data = SourceLocation.fromCurrentContext("com.google", "sun", "java", "org");
+    assertNull(data);
   }
 
   private void compareSourceLocation(SourceLocation expected, SourceLocation value) {

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/SourceLocationTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/SourceLocationTest.java
@@ -92,7 +92,7 @@ public class SourceLocationTest {
 
   @Test
   public void testFromCurrentContextWithVeryLargeLevel() {
-    SourceLocation data = SourceLocation.fromCurrentContext("com.google", "sun", "java", "org");
+    SourceLocation data = SourceLocation.fromCurrentContext("com.google", "sun", "java", "jdk", "org");
     assertNull(data);
   }
 


### PR DESCRIPTION
Add configuration (edited:) `redirectoToStdout`~~`useStructuredLogging`~~ to `LoggingHandler` class to support an option to print logs to STDOUT formatted as a one line Json and following the [structured logging](https://cloud.google.com/logging/docs/structured-logging) guidelines.
Implement Jsonification of the `LogEntry` object following the structured logging format.
Move metadata population to a standalone API to be used by `LoggingHandler` explicitly.