### PR TITLE
fix: use initialized logging option in constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-4]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-logging/java8-win.html
 [kokoro-badge-image-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-logging/java11.svg
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-logging/java11.html
-[stability-image]: https://img.shields.io/badge/stability-unknown-red
+[stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-logging.svg
 [maven-version-link]: https://search.maven.org/search?q=g:com.google.cloud%20AND%20a:google-cloud-logging&core=gav
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-4]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-logging/java8-win.html
 [kokoro-badge-image-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-logging/java11.svg
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-logging/java11.html
-[stability-image]: https://img.shields.io/badge/stability-stable-green
+[stability-image]: https://img.shields.io/badge/stability-unknown-red
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-logging.svg
 [maven-version-link]: https://search.maven.org/search?q=g:com.google.cloud%20AND%20a:google-cloud-logging&core=gav
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingHandler.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingHandler.java
@@ -241,7 +241,7 @@ public class LoggingHandler extends Handler {
       setLevel(level);
       baseLevel = level.equals(Level.ALL) ? Level.FINEST : level;
       flushLevel = config.getFlushLevel();
-      Boolean f1 = options.getAutoPopulateMetadata();
+      Boolean f1 = loggingOptions.getAutoPopulateMetadata();
       Boolean f2 = config.getAutoPopulateMetadata();
       autoPopulateMetadata = isTrueOrNull(f1) && isTrueOrNull(f2);
       redirectToStdout = firstNonNull(config.getRedirectToStdout(), Boolean.FALSE);

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
@@ -224,7 +224,14 @@ public class LoggingHandlerTest {
 
   @Test
   public void testDefaultHandlerCreation() {
-    replay(options, logging);
+    // mocks behavior of MonitoredResourceUtil which is used by LoggingOptions.getDefaultInstance()
+    // static method
+    ResourceTypeEnvironmentGetter getterMock =
+        EasyMock.createMock(ResourceTypeEnvironmentGetter.class);
+    expect(getterMock.getAttribute("project/project-id")).andReturn(PROJECT);
+    expect(getterMock.getAttribute("")).andStubReturn(null);
+    MonitoredResourceUtil.setEnvironmentGetter(getterMock);
+    replay(options, logging, getterMock);
     assertNotNull(new LoggingHandler());
   }
 

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
@@ -53,6 +53,7 @@ public class LoggingHandlerTest {
   private static final String LOG_NAME = "java.log";
   private static final String MESSAGE = "message";
   private static final String PROJECT = "project";
+  private static final String PROJECT_ENV_NAME = "GOOGLE_CLOUD_PROJECT";
 
   private static final MonitoredResource DEFAULT_RESOURCE =
       MonitoredResource.of("global", ImmutableMap.of("project_id", PROJECT));
@@ -224,15 +225,15 @@ public class LoggingHandlerTest {
 
   @Test
   public void testDefaultHandlerCreation() {
-    // mocks behavior of MonitoredResourceUtil which is used by LoggingOptions.getDefaultInstance()
-    // static method
-    ResourceTypeEnvironmentGetter getterMock =
-        EasyMock.createMock(ResourceTypeEnvironmentGetter.class);
-    expect(getterMock.getAttribute("project/project-id")).andReturn(PROJECT);
-    expect(getterMock.getAttribute("")).andStubReturn(null);
-    MonitoredResourceUtil.setEnvironmentGetter(getterMock);
-    replay(options, logging, getterMock);
+    String oldProject = System.getProperty(PROJECT_ENV_NAME);
+    System.setProperty(PROJECT_ENV_NAME, PROJECT);
+    replay(options, logging);
     assertNotNull(new LoggingHandler());
+    if (oldProject != null) {
+      System.setProperty(PROJECT_ENV_NAME, oldProject);
+    } else {
+      System.clearProperty(PROJECT_ENV_NAME);
+    }
   }
 
   @Test

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
@@ -22,6 +22,7 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.api.client.util.Strings;
@@ -205,9 +206,9 @@ public class LoggingHandlerTest {
     expect(options.getService()).andStubReturn(logging);
     expect(options.getAutoPopulateMetadata()).andStubReturn(Boolean.FALSE);
     logging.setFlushSeverity(EasyMock.anyObject(Severity.class));
-    expectLastCall().once();
+    expectLastCall().anyTimes();
     logging.setWriteSynchronicity(EasyMock.anyObject(Synchronicity.class));
-    expectLastCall().once();
+    expectLastCall().anyTimes();
   }
 
   @After
@@ -219,6 +220,12 @@ public class LoggingHandlerTest {
     LogRecord record = new LogRecord(level, message);
     record.setMillis(123456789L);
     return record;
+  }
+
+  @Test
+  public void testDefaultHandlerCreation() {
+    replay(options, logging);
+    assertNotNull(new LoggingHandler());
   }
 
   @Test
@@ -483,6 +490,7 @@ public class LoggingHandlerTest {
 
   @Test
   public void testSyncWrite() {
+    reset(logging);
     LogEntry entry =
         LogEntry.newBuilder(Payload.StringPayload.of(MESSAGE))
             .setSeverity(Severity.DEBUG)
@@ -491,10 +499,10 @@ public class LoggingHandlerTest {
             .setTimestamp(123456789L)
             .build();
 
+    logging.setWriteSynchronicity(Synchronicity.ASYNC);
     logging.setWriteSynchronicity(Synchronicity.SYNC);
-    expectLastCall().once();
     logging.write(ImmutableList.of(entry), DEFAULT_OPTIONS);
-    expectLastCall().once();
+    logging.setFlushSeverity(Severity.ERROR);
     replay(options, logging);
 
     LoggingHandler handler = new LoggingHandler(LOG_NAME, options, DEFAULT_RESOURCE);


### PR DESCRIPTION
Use the initialized variable instead of the argument that can be null.
Add unit test to validate LoggingHandler construction with default args.

Fixes #842
