### PR TITLE
fix(deps): set gson via java-shared-deps

### DIFF
--- a/google-cloud-logging/pom.xml
+++ b/google-cloud-logging/pom.xml
@@ -24,7 +24,6 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.9.0</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>


### PR DESCRIPTION
Gson dependency version should be set by the java-shared-dependencies BOM, so that the artifacts listed in the google-cloud-bom have the same set of the dependencies.

This should fix one of the problems in https://github.com/googleapis/java-cloud-bom/pull/3593#issuecomment-1048129051.

CC: @Neenu1995 

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-logging/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
