### PR TITLE
fix: do not use GAE_RUNTIME environment variable for GAE environment detection

### DIFF
--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/MonitoredResourceUtil.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/MonitoredResourceUtil.java
@@ -175,7 +175,6 @@ public class MonitoredResourceUtil {
       return Resource.CloudRun;
     }
     if (getter.getEnv("GAE_INSTANCE") != null
-        && getter.getEnv("GAE_RUNTIME") != null
         && getter.getEnv("GAE_SERVICE") != null
         && getter.getEnv("GAE_VERSION") != null) {
       return Resource.AppEngine;

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/MonitoredResourceUtilTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/MonitoredResourceUtilTest.java
@@ -155,7 +155,6 @@ public class MonitoredResourceUtilTest {
   private void setupCommonGAEMocks(String mockedModuleId, String mockedVersionId) {
     expect(getterMock.getAttribute("instance/zone")).andReturn(MOCKED_QUALIFIED_ZONE).once();
     expect(getterMock.getEnv("GAE_INSTANCE")).andReturn(MOCKED_NON_EMPTY).once();
-    expect(getterMock.getEnv("GAE_RUNTIME")).andReturn(MOCKED_NON_EMPTY).once();
     expect(getterMock.getEnv("GAE_SERVICE")).andReturn(mockedModuleId).times(2);
     expect(getterMock.getEnv("GAE_VERSION")).andReturn(mockedVersionId).times(2);
     expect(getterMock.getEnv(anyString())).andReturn(null).anyTimes();


### PR DESCRIPTION
Stops using GAE_RUNTIME environment variable to detect AppEngine environment.

AppEngine environments with custom runtimes ([doc](https://cloud.google.com/appengine/docs/flexible/custom-runtimes)) do not set `GAE_RUNTIME` environment variable. It fails the current detection logic from correctly identifying `gae_app` resource type in such environments.

Fixes #890 
