### PR TITLE
fix: Async logging should not rethrow error in onFailure callback

### DIFF
--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -882,7 +882,7 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
     try {
       ApiFutures.allAsList(writesToFlush).get(FLUSH_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      throw new RuntimeException(e);
+      System.err.println("ERROR: flush failure: " + e);
     }
   }
 


### PR DESCRIPTION
Async logging should not rethrow error in onFailure callback and print error in System.err

Fixes [#645](https://github.com/googleapis/java-logging/issues/645☕️)

