### PR TITLE
fix: Async logging should not rethrow error in onFailure callback correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:25.0.0')
+implementation platform('com.google.cloud:libraries-bom:25.1.0')
 
 implementation 'com.google.cloud:google-cloud-logging'
 ```

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -882,7 +882,7 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
     try {
       ApiFutures.allAsList(writesToFlush).get(FLUSH_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      System.err.println("ERROR: flush failure: " + e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -940,7 +940,7 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
               public void onFailure(Throwable t) {
                 try {
                   Exception ex = t instanceof Exception ? (Exception) t : new Exception(t);
-                  throw new RuntimeException(ex);
+                  System.err.println("ERROR: onFailure exception: " + ex);
                 } finally {
                   removeFromPending();
                 }


### PR DESCRIPTION
Making a correction for previous fix

Fixes [#645](https://github.com/googleapis/java-logging/issues/645) ☕️

