### PR TITLE
feat: Add support for library instrumentation

### DIFF
--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
@@ -38,6 +38,7 @@ public class Instrumentation {
   public static final String INSTRUMENTATION_VERSION_KEY = "version";
   public static final String JAVA_LIBRARY_NAME_PREFIX = "java";
   public static final String DEFAULT_INSTRUMENTATION_VERSION = "UNKNOWN";
+  public static final String INSTRUMENTATION_LOG_NAME = "diagnostic-log";
   public static final int MAX_DIAGNOSTIC_VALUE_LENGTH = 14;
   public static final int MAX_DIAGNOSTIC_ENTIES = 3;
   private static boolean instrumentationAdded = false;
@@ -132,14 +133,16 @@ public class Instrumentation {
                         .build()))
             .build();
     LogEntry entry =
-        LogEntry.of(
-            JsonPayload.of(
-                Struct.newBuilder()
-                    .putAllFields(
-                        ImmutableMap.of(
-                            DIAGNOSTIC_INFO_KEY,
-                            Value.newBuilder().setStructValue(instrumentation).build()))
-                    .build()));
+        LogEntry.newBuilder(
+                JsonPayload.of(
+                    Struct.newBuilder()
+                        .putAllFields(
+                            ImmutableMap.of(
+                                DIAGNOSTIC_INFO_KEY,
+                                Value.newBuilder().setStructValue(instrumentation).build()))
+                        .build()))
+            .setLogName(INSTRUMENTATION_LOG_NAME)
+            .build();
     return entry;
   }
 

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging;
+
+import com.google.api.client.util.Strings;
+import com.google.api.gax.core.GaxProperties;
+import com.google.cloud.Tuple;
+import com.google.cloud.logging.Payload.JsonPayload;
+import com.google.cloud.logging.Payload.Type;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Instrumentation {
+  public static final String DIAGNOSTIC_INFO_KEY = "logging.googleapis.com/diagnostic";
+  public static final String INSTRUMENTATION_SOURCE_KEY = "instrumentation_source";
+  public static final String INSTRUMENTATION_NAME_KEY = "name";
+  public static final String INSTRUMENTATION_VERSION_KEY = "version";
+  public static final String JAVA_LIBRARY_NAME_PREFIX = "java";
+  public static final String DEFAULT_INSTRUMENTATION_VERSION = "UNKNOWN";
+  public static final int MAX_DIAGNOSTIC_VALUE_LENGTH = 14;
+  public static final int MAX_DIAGNOSTIC_ENTIES = 3;
+  private static boolean instrumentationAdded = false;
+
+  public static Tuple<Boolean, Iterable<LogEntry>> populateInstrumentationInfo(
+      Iterable<LogEntry> logEntries) {
+    boolean isWritten = setInstrumentationStatus(true);
+    List<LogEntry> entries = new ArrayList<>();
+    boolean isInfoAdded = false;
+    for (LogEntry logEntry : logEntries) {
+      // Check if LogEntry has a proper payload and also contains a diagnostic entry
+      if (logEntry.getPayload().getType() == Type.JSON
+          && logEntry
+              .<Payload.JsonPayload>getPayload()
+              .getData()
+              .containsFields(DIAGNOSTIC_INFO_KEY)) {
+        try {
+          ListValue infoList =
+              logEntry
+                  .<Payload.JsonPayload>getPayload()
+                  .getData()
+                  .getFieldsOrThrow(DIAGNOSTIC_INFO_KEY)
+                  .getStructValue()
+                  .getFieldsOrThrow(INSTRUMENTATION_SOURCE_KEY)
+                  .getListValue();
+          entries.add(createDiagnosticEntry(null, null, infoList));
+          isInfoAdded = isWritten = true;
+        } catch (Exception ex) {
+          System.err.println("ERROR: unexpected exception in populateInstrumentationInfo: " + ex);
+        }
+      } else {
+        entries.add(logEntry);
+      }
+    }
+    if (!isWritten) {
+      entries.add(createDiagnosticEntry(null, null, null));
+      isInfoAdded = true;
+    }
+    return Tuple.of(isInfoAdded, entries);
+  }
+
+  /**
+   * The helper method to generate a log entry with diagnostic instrumentation data.
+   *
+   * @param libraryName {string} The name of the logging library to be reported. Should be prefixed
+   *     with 'java'. Will be truncated if longer than 14 characters.
+   * @param libraryVersion {string} The version of the logging library to be reported. Will be
+   *     truncated if longer than 14 characters.
+   * @returns {LogEntry} The entry with diagnostic instrumentation data.
+   */
+  public static LogEntry createDiagnosticEntry(String libraryName, String libraryVersion) {
+    return createDiagnosticEntry(libraryName, libraryVersion, null);
+  }
+
+  private static LogEntry createDiagnosticEntry(
+      String libraryName, String libraryVersion, ListValue existingLibraryList) {
+    Struct instrumentation =
+        Struct.newBuilder()
+            .putAllFields(
+                ImmutableMap.of(
+                    INSTRUMENTATION_SOURCE_KEY,
+                    Value.newBuilder()
+                        .setListValue(
+                            generateLibrariesList(libraryName, libraryVersion, existingLibraryList))
+                        .build()))
+            .build();
+    LogEntry entry =
+        LogEntry.of(
+            JsonPayload.of(
+                Struct.newBuilder()
+                    .putAllFields(
+                        ImmutableMap.of(
+                            DIAGNOSTIC_INFO_KEY,
+                            Value.newBuilder().setStructValue(instrumentation).build()))
+                    .build()));
+    return entry;
+  }
+
+  private static ListValue generateLibrariesList(
+      String libraryName, String libraryVersion, ListValue existingLibraryList) {
+    if (Strings.isNullOrEmpty(libraryName) || !libraryName.startsWith(JAVA_LIBRARY_NAME_PREFIX))
+      libraryName = JAVA_LIBRARY_NAME_PREFIX;
+    if (Strings.isNullOrEmpty(libraryVersion)) {
+      libraryVersion = GaxProperties.getLibraryVersion(Instrumentation.class.getClass());
+      if (Strings.isNullOrEmpty(libraryVersion)) libraryVersion = DEFAULT_INSTRUMENTATION_VERSION;
+    }
+    Struct libraryInfo = createInfoStruct(libraryName, libraryVersion);
+    ListValue.Builder libraryList = ListValue.newBuilder();
+    // Append first the library info for this library
+    libraryList.addValues(Value.newBuilder().setStructValue(libraryInfo).build());
+    if (existingLibraryList != null) {
+      for (Value val : existingLibraryList.getValuesList()) {
+        if (val.hasStructValue()) {
+          try {
+            String name =
+                val.getStructValue().getFieldsOrThrow(INSTRUMENTATION_NAME_KEY).getStringValue();
+            if (Strings.isNullOrEmpty(name) || !name.startsWith(JAVA_LIBRARY_NAME_PREFIX)) continue;
+            String version =
+                val.getStructValue().getFieldsOrThrow(INSTRUMENTATION_VERSION_KEY).getStringValue();
+            if (Strings.isNullOrEmpty(version)) continue;
+            libraryList.addValues(
+                Value.newBuilder().setStructValue(createInfoStruct(name, version)).build());
+            if (libraryList.getValuesCount() == MAX_DIAGNOSTIC_ENTIES) break;
+          } catch (Exception ex) {
+            System.err.println("ERROR: unexpected exception in generateLibrariesList: " + ex);
+          }
+        }
+      }
+    }
+    return libraryList.build();
+  }
+
+  private static Struct createInfoStruct(String libraryName, String libraryVersion) {
+    return Struct.newBuilder()
+        .putAllFields(
+            ImmutableMap.of(
+                INSTRUMENTATION_NAME_KEY,
+                    Value.newBuilder().setStringValue(truncateValue(libraryName)).build(),
+                INSTRUMENTATION_VERSION_KEY,
+                    Value.newBuilder().setStringValue(truncateValue(libraryVersion)).build()))
+        .build();
+  }
+
+  /**
+   * The helper method used to set a status of a flag which indicates if instrumentation info
+   * already written or not.
+   *
+   * @param value {boolean} The value to be set.
+   * @returns The value of the flag before it is set.
+   */
+  public static boolean setInstrumentationStatus(boolean value) {
+    if (instrumentationAdded == value) return instrumentationAdded;
+    return setAndGetInstrumentationStatus(value);
+  }
+
+  private static synchronized boolean setAndGetInstrumentationStatus(boolean value) {
+    boolean current = instrumentationAdded;
+    instrumentationAdded = value;
+    return current;
+  }
+
+  private static String truncateValue(String value) {
+    if (Strings.isNullOrEmpty(value) || value.length() < MAX_DIAGNOSTIC_VALUE_LENGTH) return value;
+    return value.substring(0, MAX_DIAGNOSTIC_VALUE_LENGTH) + "*";
+  }
+}

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
@@ -52,7 +52,7 @@ public class Instrumentation {
    */
   public static Tuple<Boolean, Iterable<LogEntry>> populateInstrumentationInfo(
       Iterable<LogEntry> logEntries) {
-    boolean isWritten = setInstrumentationStatus(true);
+    boolean isWritten = setInstrumentationStatus();
     if (isWritten) return Tuple.of(false, logEntries);
     List<LogEntry> entries = new ArrayList<>();
 
@@ -96,6 +96,7 @@ public class Instrumentation {
    *     true
    */
   public static WriteOption[] addPartialSuccessOption(WriteOption[] options) {
+    if (options == null) return options;
     List<WriteOption> writeOptions = new ArrayList<WriteOption>();
     writeOptions.addAll(Arrays.asList(options));
     // Make sure we remove all partial success flags if any exist
@@ -186,19 +187,25 @@ public class Instrumentation {
   }
 
   /**
-   * The helper method used to set a status of a flag which indicates if instrumentation info
-   * already written or not.
+   * The helper method used to set to true the flag which indicates if instrumentation info already
+   * written or not.
    *
-   * @param value {boolean} The value to be set.
    * @returns The value of the flag before it was set.
    */
-  public static boolean setInstrumentationStatus(boolean value) {
-    if (instrumentationAdded == value) return instrumentationAdded;
+  public static boolean setInstrumentationStatus() {
+    if (instrumentationAdded) return instrumentationAdded;
     synchronized (instrumentationLock) {
-      boolean current = instrumentationAdded;
-      instrumentationAdded = value;
-      return current;
+      instrumentationAdded = true;
+      return false;
     }
+  }
+
+  /**
+   * The package-private method to reset an instrumentation status to false to be used for testing
+   * purposes
+   */
+  static void resetInstrumentationStatus() {
+    instrumentationAdded = false;
   }
 
   /**

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
@@ -52,7 +52,7 @@ public class Instrumentation {
    */
   public static Tuple<Boolean, Iterable<LogEntry>> populateInstrumentationInfo(
       Iterable<LogEntry> logEntries) {
-    boolean isWritten = setInstrumentationStatus();
+    boolean isWritten = setInstrumentationStatus(true);
     if (isWritten) return Tuple.of(false, logEntries);
     List<LogEntry> entries = new ArrayList<>();
 
@@ -187,25 +187,18 @@ public class Instrumentation {
   }
 
   /**
-   * The helper method used to set to true the flag which indicates if instrumentation info already
-   * written or not.
+   * The package-private helper method used to set the flag which indicates if instrumentation info
+   * already written or not.
    *
    * @returns The value of the flag before it was set.
    */
-  public static boolean setInstrumentationStatus() {
-    if (instrumentationAdded) return instrumentationAdded;
+  static boolean setInstrumentationStatus(boolean value) {
+    if (instrumentationAdded == value) return instrumentationAdded;
     synchronized (instrumentationLock) {
-      instrumentationAdded = true;
-      return false;
+      boolean current = instrumentationAdded;
+      instrumentationAdded = value;
+      return current;
     }
-  }
-
-  /**
-   * The package-private method to reset an instrumentation status to false to be used for testing
-   * purposes
-   */
-  static void resetInstrumentationStatus() {
-    instrumentationAdded = false;
   }
 
   /**

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
@@ -119,8 +119,7 @@ public class Instrumentation {
     if (Strings.isNullOrEmpty(libraryName) || !libraryName.startsWith(JAVA_LIBRARY_NAME_PREFIX))
       libraryName = JAVA_LIBRARY_NAME_PREFIX;
     if (Strings.isNullOrEmpty(libraryVersion)) {
-      libraryVersion = GaxProperties.getLibraryVersion(Instrumentation.class.getClass());
-      if (Strings.isNullOrEmpty(libraryVersion)) libraryVersion = DEFAULT_INSTRUMENTATION_VERSION;
+      libraryVersion = getLibraryVersion(Instrumentation.class.getClass());
     }
     Struct libraryInfo = createInfoStruct(libraryName, libraryVersion);
     ListValue.Builder libraryList = ListValue.newBuilder();
@@ -169,6 +168,19 @@ public class Instrumentation {
   public static boolean setInstrumentationStatus(boolean value) {
     if (instrumentationAdded == value) return instrumentationAdded;
     return setAndGetInstrumentationStatus(value);
+  }
+
+  /**
+   * Returns a library version associated with given class
+   *
+   * @param libraryClass {Class<?>} The class to be used to determine a library version
+   * @return The version number string for given class or "UNKNOWN" if class library version cannot
+   *     be detected
+   */
+  public static String getLibraryVersion(Class<?> libraryClass) {
+    String libraryVersion = GaxProperties.getLibraryVersion(libraryClass);
+    if (Strings.isNullOrEmpty(libraryVersion)) libraryVersion = DEFAULT_INSTRUMENTATION_VERSION;
+    return libraryVersion;
   }
 
   private static synchronized boolean setAndGetInstrumentationStatus(boolean value) {

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
@@ -71,7 +71,8 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
       RESOURCE,
       LABELS,
       LOG_DESTINATION,
-      AUTO_POPULATE_METADATA;
+      AUTO_POPULATE_METADATA,
+      PARTIAL_SUCCESS;
 
       @SuppressWarnings("unchecked")
       <T> T get(Map<Option.OptionType, ?> options) {
@@ -122,6 +123,15 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
      */
     public static WriteOption autoPopulateMetadata(boolean autoPopulateMetadata) {
       return new WriteOption(OptionType.AUTO_POPULATE_METADATA, autoPopulateMetadata);
+    }
+
+    /**
+     * Returns an option to set partialSuccess flag. See {@link
+     * https://cloud.google.com/logging/docs/reference/v2/rest/v2/entries/write#body.request_body.FIELDS.partial_success}
+     * for more details.
+     */
+    public static WriteOption partialSuccess(boolean partialSuccess) {
+      return new WriteOption(OptionType.PARTIAL_SUCCESS, partialSuccess);
     }
   }
 

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingHandler.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingHandler.java
@@ -19,6 +19,7 @@ package com.google.cloud.logging;
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 import com.google.cloud.MonitoredResource;
+import com.google.cloud.Tuple;
 import com.google.cloud.logging.Logging.WriteOption;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -312,7 +313,9 @@ public class LoggingHandler extends Handler {
     }
     if (logEntry != null) {
       try {
-        Iterable<LogEntry> logEntries = ImmutableList.of(logEntry);
+        Tuple<Boolean, Iterable<LogEntry>> pair =
+            Instrumentation.populateInstrumentationInfo(ImmutableList.of(logEntry));
+        Iterable<LogEntry> logEntries = pair.y();
         if (autoPopulateMetadata) {
           logEntries =
               logging.populateMetadata(
@@ -321,7 +324,15 @@ public class LoggingHandler extends Handler {
         if (redirectToStdout) {
           logEntries.forEach(log -> System.out.println(log.toStructuredJsonString()));
         } else {
-          logging.write(logEntries, defaultWriteOptions);
+          // Add partialSuccess option always for request containing instrumentation data
+          if (pair.x()) {
+            List<WriteOption> writeOptions = new ArrayList<WriteOption>();
+            writeOptions.addAll(Arrays.asList(defaultWriteOptions));
+            writeOptions.add(WriteOption.partialSuccess(true));
+            logging.write(logEntries, Iterables.toArray(writeOptions, WriteOption.class));
+          } else {
+            logging.write(logEntries, defaultWriteOptions);
+          }
         }
       } catch (Exception ex) {
         getErrorManager().error(null, ex, ErrorManager.WRITE_FAILURE);

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -23,6 +23,7 @@ import static com.google.cloud.logging.Logging.ListOption.OptionType.PAGE_TOKEN;
 import static com.google.cloud.logging.Logging.WriteOption.OptionType.LABELS;
 import static com.google.cloud.logging.Logging.WriteOption.OptionType.LOG_DESTINATION;
 import static com.google.cloud.logging.Logging.WriteOption.OptionType.LOG_NAME;
+import static com.google.cloud.logging.Logging.WriteOption.OptionType.PARTIAL_SUCCESS;
 import static com.google.cloud.logging.Logging.WriteOption.OptionType.RESOURCE;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -92,7 +93,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
-
   protected static final String RESOURCE_NAME_FORMAT = "projects/%s/traces/%s";
   private static final int FLUSH_WAIT_TIMEOUT_SECONDS = 6;
   private final LoggingRpc rpc;
@@ -774,6 +774,7 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
       builder.putAllLabels(labels);
     }
 
+    builder.setPartialSuccess(Boolean.TRUE.equals(PARTIAL_SUCCESS.get(options)));
     builder.addAllEntries(Iterables.transform(logEntries, LogEntry.toPbFunction(projectId)));
     return builder.build();
   }

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/InstrumentationTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/InstrumentationTest.java
@@ -48,7 +48,8 @@ public class InstrumentationTest {
         1,
         2,
         new HashSet<>(Arrays.asList(Instrumentation.JAVA_LIBRARY_NAME_PREFIX)),
-        new HashSet<>(Arrays.asList(Instrumentation.DEFAULT_INSTRUMENTATION_VERSION)));
+        new HashSet<>(
+            Arrays.asList(Instrumentation.getLibraryVersion(Instrumentation.class.getClass()))));
   }
 
   @Test
@@ -74,7 +75,9 @@ public class InstrumentationTest {
         1,
         new HashSet<>(Arrays.asList(Instrumentation.JAVA_LIBRARY_NAME_PREFIX, JAVA_OTHER_NAME)),
         new HashSet<>(
-            Arrays.asList(Instrumentation.DEFAULT_INSTRUMENTATION_VERSION, JAVA_OTHER_VERSION)));
+            Arrays.asList(
+                Instrumentation.getLibraryVersion(Instrumentation.class.getClass()),
+                JAVA_OTHER_VERSION)));
   }
 
   @Test
@@ -88,7 +91,8 @@ public class InstrumentationTest {
         0,
         1,
         new HashSet<>(Arrays.asList(Instrumentation.JAVA_LIBRARY_NAME_PREFIX)),
-        new HashSet<>(Arrays.asList(Instrumentation.DEFAULT_INSTRUMENTATION_VERSION)));
+        new HashSet<>(
+            Arrays.asList(Instrumentation.getLibraryVersion(Instrumentation.class.getClass()))));
   }
 
   public static JsonPayload generateInstrumentationPayload(

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/InstrumentationTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/InstrumentationTest.java
@@ -42,7 +42,7 @@ public class InstrumentationTest {
 
   @Test
   public void testInstrumentationGenerated() {
-    Instrumentation.resetInstrumentationStatus();
+    Instrumentation.setInstrumentationStatus(false);
     verifyEntries(
         Instrumentation.populateInstrumentationInfo(ImmutableList.of(STRING_ENTRY)),
         1,
@@ -54,7 +54,7 @@ public class InstrumentationTest {
 
   @Test
   public void testNoInstrumentationGenerated() {
-    Instrumentation.setInstrumentationStatus();
+    Instrumentation.setInstrumentationStatus(true);
     Tuple<Boolean, Iterable<LogEntry>> pair =
         Instrumentation.populateInstrumentationInfo(ImmutableList.of(STRING_ENTRY));
     ArrayList<LogEntry> entries = Lists.newArrayList(pair.y());
@@ -65,7 +65,7 @@ public class InstrumentationTest {
 
   @Test
   public void testInstrumentationUpdated() {
-    Instrumentation.resetInstrumentationStatus();
+    Instrumentation.setInstrumentationStatus(false);
     LogEntry json_entry =
         LogEntry.newBuilder(generateInstrumentationPayload(JAVA_OTHER_NAME, JAVA_OTHER_VERSION))
             .build();
@@ -82,7 +82,7 @@ public class InstrumentationTest {
 
   @Test
   public void testInvalidInstrumentationRemoved() {
-    Instrumentation.resetInstrumentationStatus();
+    Instrumentation.setInstrumentationStatus(false);
     LogEntry json_entry =
         LogEntry.newBuilder(generateInstrumentationPayload(JAVA_INVALID_NAME, JAVA_OTHER_VERSION))
             .build();

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/InstrumentationTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/InstrumentationTest.java
@@ -42,7 +42,7 @@ public class InstrumentationTest {
 
   @Test
   public void testInstrumentationGenerated() {
-    Instrumentation.setInstrumentationStatus(false);
+    Instrumentation.resetInstrumentationStatus();
     verifyEntries(
         Instrumentation.populateInstrumentationInfo(ImmutableList.of(STRING_ENTRY)),
         1,
@@ -54,7 +54,7 @@ public class InstrumentationTest {
 
   @Test
   public void testNoInstrumentationGenerated() {
-    Instrumentation.setInstrumentationStatus(true);
+    Instrumentation.setInstrumentationStatus();
     Tuple<Boolean, Iterable<LogEntry>> pair =
         Instrumentation.populateInstrumentationInfo(ImmutableList.of(STRING_ENTRY));
     ArrayList<LogEntry> entries = Lists.newArrayList(pair.y());
@@ -65,7 +65,7 @@ public class InstrumentationTest {
 
   @Test
   public void testInstrumentationUpdated() {
-    Instrumentation.setInstrumentationStatus(false);
+    Instrumentation.resetInstrumentationStatus();
     LogEntry json_entry =
         LogEntry.newBuilder(generateInstrumentationPayload(JAVA_OTHER_NAME, JAVA_OTHER_VERSION))
             .build();
@@ -82,7 +82,7 @@ public class InstrumentationTest {
 
   @Test
   public void testInvalidInstrumentationRemoved() {
-    Instrumentation.setInstrumentationStatus(false);
+    Instrumentation.resetInstrumentationStatus();
     LogEntry json_entry =
         LogEntry.newBuilder(generateInstrumentationPayload(JAVA_INVALID_NAME, JAVA_OTHER_VERSION))
             .build();

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/InstrumentationTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/InstrumentationTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging;
+
+import com.google.api.client.util.Lists;
+import com.google.cloud.Tuple;
+import com.google.cloud.logging.Payload.JsonPayload;
+import com.google.cloud.logging.Payload.StringPayload;
+import com.google.cloud.logging.Payload.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Value;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class InstrumentationTest {
+  private static final StringPayload STRING_PAYLOAD = StringPayload.of("payload");
+  private static final LogEntry STRING_ENTRY = LogEntry.newBuilder(STRING_PAYLOAD).build();
+  private static final String JAVA_OTHER_NAME = "java-other";
+  private static final String JAVA_INVALID_NAME = "no-java-name";
+  private static final String JAVA_OTHER_VERSION = "1.0.0";
+
+  @Test
+  public void testInstrumentationGenerated() {
+    Instrumentation.setInstrumentationStatus(false);
+    verifyEntries(
+        Instrumentation.populateInstrumentationInfo(ImmutableList.of(STRING_ENTRY)),
+        1,
+        2,
+        new HashSet<>(Arrays.asList(Instrumentation.JAVA_LIBRARY_NAME_PREFIX)),
+        new HashSet<>(Arrays.asList(Instrumentation.DEFAULT_INSTRUMENTATION_VERSION)));
+  }
+
+  @Test
+  public void testNoInstrumentationGenerated() {
+    Instrumentation.setInstrumentationStatus(true);
+    Tuple<Boolean, Iterable<LogEntry>> pair =
+        Instrumentation.populateInstrumentationInfo(ImmutableList.of(STRING_ENTRY));
+    ArrayList<LogEntry> entries = Lists.newArrayList(pair.y());
+    Assert.assertFalse(pair.x());
+    Assert.assertEquals(entries.size(), 1);
+    Assert.assertTrue(entries.get(0).getPayload().getType() == Type.STRING);
+  }
+
+  @Test
+  public void testInstrumentationUpdated() {
+    Instrumentation.setInstrumentationStatus(false);
+    LogEntry json_entry =
+        LogEntry.newBuilder(generateInstrumentationPayload(JAVA_OTHER_NAME, JAVA_OTHER_VERSION))
+            .build();
+    verifyEntries(
+        Instrumentation.populateInstrumentationInfo(ImmutableList.of(json_entry)),
+        0,
+        1,
+        new HashSet<>(Arrays.asList(Instrumentation.JAVA_LIBRARY_NAME_PREFIX, JAVA_OTHER_NAME)),
+        new HashSet<>(
+            Arrays.asList(Instrumentation.DEFAULT_INSTRUMENTATION_VERSION, JAVA_OTHER_VERSION)));
+  }
+
+  @Test
+  public void testInvalidInstrumentationRemoved() {
+    Instrumentation.setInstrumentationStatus(false);
+    LogEntry json_entry =
+        LogEntry.newBuilder(generateInstrumentationPayload(JAVA_INVALID_NAME, JAVA_OTHER_VERSION))
+            .build();
+    verifyEntries(
+        Instrumentation.populateInstrumentationInfo(ImmutableList.of(json_entry)),
+        0,
+        1,
+        new HashSet<>(Arrays.asList(Instrumentation.JAVA_LIBRARY_NAME_PREFIX)),
+        new HashSet<>(Arrays.asList(Instrumentation.DEFAULT_INSTRUMENTATION_VERSION)));
+  }
+
+  public static JsonPayload generateInstrumentationPayload(
+      String libraryName, String libraryVersion) {
+    Map<String, Object> json_data = new HashMap<>();
+    Map<String, Object> instrumentation_data = new HashMap<>();
+    Map<String, Object> info = new HashMap<>();
+    info.put(Instrumentation.INSTRUMENTATION_NAME_KEY, libraryName);
+    info.put(Instrumentation.INSTRUMENTATION_VERSION_KEY, libraryVersion);
+    List<Object> list = ImmutableList.<Object>of(info);
+    instrumentation_data.put(Instrumentation.INSTRUMENTATION_SOURCE_KEY, list);
+    json_data.put(Instrumentation.DIAGNOSTIC_INFO_KEY, instrumentation_data);
+    return JsonPayload.of(json_data);
+  }
+
+  private static void verifyEntries(
+      Tuple<Boolean, Iterable<LogEntry>> pair,
+      int index,
+      int expected,
+      HashSet<String> names,
+      HashSet<String> versions) {
+    ArrayList<LogEntry> entries = Lists.newArrayList(pair.y());
+    Assert.assertTrue(pair.x());
+    Assert.assertEquals(entries.size(), expected);
+    Assert.assertTrue(entries.get(index).getPayload().getType() == Type.JSON);
+    ListValue infoList =
+        entries
+            .get(index)
+            .<Payload.JsonPayload>getPayload()
+            .getData()
+            .getFieldsOrThrow(Instrumentation.DIAGNOSTIC_INFO_KEY)
+            .getStructValue()
+            .getFieldsOrThrow(Instrumentation.INSTRUMENTATION_SOURCE_KEY)
+            .getListValue();
+    for (Value val : infoList.getValuesList()) {
+      Assert.assertTrue(
+          names.remove(
+              val.getStructValue()
+                  .getFieldsOrThrow(Instrumentation.INSTRUMENTATION_NAME_KEY)
+                  .getStringValue()));
+      Assert.assertTrue(
+          versions.remove(
+              val.getStructValue()
+                  .getFieldsOrThrow(Instrumentation.INSTRUMENTATION_VERSION_KEY)
+                  .getStringValue()));
+    }
+    Assert.assertEquals(names.size(), 0);
+    Assert.assertEquals(versions.size(), 0);
+  }
+}

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
@@ -201,7 +201,7 @@ public class LoggingHandlerTest {
 
   @Before
   public void setUp() {
-    Instrumentation.setInstrumentationStatus(true);
+    Instrumentation.setInstrumentationStatus();
     logging = EasyMock.createMock(Logging.class);
     options = EasyMock.createMock(LoggingOptions.class);
     expect(options.getProjectId()).andStubReturn(PROJECT);

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
@@ -636,7 +636,7 @@ public class LoggingHandlerTest {
         LogEntry.newBuilder(
                 InstrumentationTest.generateInstrumentationPayload(
                     Instrumentation.JAVA_LIBRARY_NAME_PREFIX,
-                    Instrumentation.DEFAULT_INSTRUMENTATION_VERSION))
+                    Instrumentation.getLibraryVersion(Instrumentation.class.getClass())))
             .build();
     logging.write(
         ImmutableList.of(FINEST_ENTRY, json_entry),

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
@@ -629,29 +629,6 @@ public class LoggingHandlerTest {
     System.setOut(null);
   }
 
-  @Test
-  public void testDiagnosticInfo() {
-    Instrumentation.setInstrumentationStatus(false);
-    LogEntry json_entry =
-        LogEntry.newBuilder(
-                InstrumentationTest.generateInstrumentationPayload(
-                    Instrumentation.JAVA_LIBRARY_NAME_PREFIX,
-                    Instrumentation.getLibraryVersion(Instrumentation.class.getClass())))
-            .build();
-    logging.write(
-        ImmutableList.of(FINEST_ENTRY, json_entry),
-        WriteOption.logName(LOG_NAME),
-        WriteOption.resource(DEFAULT_RESOURCE),
-        WriteOption.labels(BASE_SEVERITY_MAP),
-        WriteOption.partialSuccess(true));
-    expectLastCall().once();
-    replay(options, logging);
-    LoggingHandler handler = new LoggingHandler(LOG_NAME, options, DEFAULT_RESOURCE);
-    handler.setLevel(Level.ALL);
-    handler.setFormatter(new TestFormatter());
-    handler.publish(newLogRecord(Level.FINEST, MESSAGE));
-  }
-
   private void testPublishCustomResourceWithDestination(
       LogEntry entry, LogDestinationName destination) {
     MonitoredResource resource = MonitoredResource.of("custom", ImmutableMap.<String, String>of());

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
@@ -201,7 +201,7 @@ public class LoggingHandlerTest {
 
   @Before
   public void setUp() {
-    Instrumentation.setInstrumentationStatus();
+    Instrumentation.setInstrumentationStatus(true);
     logging = EasyMock.createMock(Logging.class);
     options = EasyMock.createMock(LoggingOptions.class);
     expect(options.getProjectId()).andStubReturn(PROJECT);

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -2306,6 +2306,7 @@ public class LoggingImplTest {
                 InstrumentationTest.generateInstrumentationPayload(
                     Instrumentation.JAVA_LIBRARY_NAME_PREFIX,
                     Instrumentation.getLibraryVersion(Instrumentation.class.getClass())))
+            .setLogName(Instrumentation.INSTRUMENTATION_LOG_NAME)
             .build();
     WriteLogEntriesRequest request =
         WriteLogEntriesRequest.newBuilder()

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -252,7 +252,7 @@ public class LoggingImplTest {
 
   @Before
   public void setUp() {
-    Instrumentation.setInstrumentationStatus();
+    Instrumentation.setInstrumentationStatus(true);
     rpcFactoryMock = EasyMock.createStrictMock(LoggingRpcFactory.class);
     loggingRpcMock = EasyMock.createStrictMock(LoggingRpc.class);
     EasyMock.expect(rpcFactoryMock.create(EasyMock.anyObject(LoggingOptions.class)))
@@ -2300,7 +2300,7 @@ public class LoggingImplTest {
   }
 
   private void testDiagnosticInfoGeneration(boolean addPartialSuccessOption) {
-    Instrumentation.resetInstrumentationStatus();
+    Instrumentation.setInstrumentationStatus(false);
     LogEntry json_entry =
         LogEntry.newBuilder(
                 InstrumentationTest.generateInstrumentationPayload(

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -252,7 +252,7 @@ public class LoggingImplTest {
 
   @Before
   public void setUp() {
-    Instrumentation.setInstrumentationStatus(true);
+    Instrumentation.setInstrumentationStatus();
     rpcFactoryMock = EasyMock.createStrictMock(LoggingRpcFactory.class);
     loggingRpcMock = EasyMock.createStrictMock(LoggingRpc.class);
     EasyMock.expect(rpcFactoryMock.create(EasyMock.anyObject(LoggingOptions.class)))
@@ -2300,7 +2300,7 @@ public class LoggingImplTest {
   }
 
   private void testDiagnosticInfoGeneration(boolean addPartialSuccessOption) {
-    Instrumentation.setInstrumentationStatus(false);
+    Instrumentation.resetInstrumentationStatus();
     LogEntry json_entry =
         LogEntry.newBuilder(
                 InstrumentationTest.generateInstrumentationPayload(

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -252,6 +252,7 @@ public class LoggingImplTest {
 
   @Before
   public void setUp() {
+    Instrumentation.setInstrumentationStatus(true);
     rpcFactoryMock = EasyMock.createStrictMock(LoggingRpcFactory.class);
     loggingRpcMock = EasyMock.createStrictMock(LoggingRpc.class);
     EasyMock.expect(rpcFactoryMock.create(EasyMock.anyObject(LoggingOptions.class)))
@@ -2286,6 +2287,41 @@ public class LoggingImplTest {
       thread.join();
     }
     assertSame(0, exceptions.get());
+  }
+
+  @Test
+  public void testDiagnosticInfoWithNoPartialSuccess() {
+    testDiagnosticInfoGeneration(false);
+  }
+
+  @Test
+  public void testDiagnosticInfoWithPartialSuccess() {
+    testDiagnosticInfoGeneration(true);
+  }
+
+  private void testDiagnosticInfoGeneration(boolean addPartialSuccessOption) {
+    Instrumentation.setInstrumentationStatus(false);
+    LogEntry json_entry =
+        LogEntry.newBuilder(
+                InstrumentationTest.generateInstrumentationPayload(
+                    Instrumentation.JAVA_LIBRARY_NAME_PREFIX,
+                    Instrumentation.getLibraryVersion(Instrumentation.class.getClass())))
+            .build();
+    WriteLogEntriesRequest request =
+        WriteLogEntriesRequest.newBuilder()
+            .addAllEntries(
+                Iterables.transform(
+                    ImmutableList.of(LOG_ENTRY1, LOG_ENTRY2, json_entry),
+                    LogEntry.toPbFunction(PROJECT)))
+            .setPartialSuccess(true)
+            .build();
+    WriteLogEntriesResponse response = WriteLogEntriesResponse.newBuilder().build();
+    EasyMock.expect(loggingRpcMock.write(request)).andReturn(ApiFutures.immediateFuture(response));
+    EasyMock.replay(rpcFactoryMock, loggingRpcMock);
+    logging = options.getService();
+    logging.write(
+        ImmutableList.of(LOG_ENTRY1, LOG_ENTRY2),
+        WriteOption.partialSuccess(addPartialSuccessOption));
   }
 
   private void testDeleteByDestination(

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingTest.java
@@ -44,6 +44,7 @@ public class LoggingTest {
   private static final String ORGANIZATION_NAME = "organization";
   private static final String BILLING_NAME = "billing";
   private static final Boolean DONT_AUTO_POPULATE_METADATA = false;
+  private static final Boolean DO_PARTIAL_SUCCESS = false;
 
   @Test
   public void testListOption() {
@@ -114,6 +115,10 @@ public class LoggingTest {
     writeOption = WriteOption.autoPopulateMetadata(DONT_AUTO_POPULATE_METADATA);
     assertEquals(DONT_AUTO_POPULATE_METADATA, writeOption.getValue());
     assertEquals(WriteOption.OptionType.AUTO_POPULATE_METADATA, writeOption.getOptionType());
+
+    writeOption = WriteOption.partialSuccess(DO_PARTIAL_SUCCESS);
+    assertEquals(DO_PARTIAL_SUCCESS, writeOption.getValue());
+    assertEquals(WriteOption.OptionType.PARTIAL_SUCCESS, writeOption.getOptionType());
   }
 
   @Test

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITJulLoggerTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITJulLoggerTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.MonitoredResource;
 import com.google.cloud.logging.BaseSystemTest;
-import com.google.cloud.logging.Instrumentation;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.LoggingHandler;
 import com.google.cloud.logging.LoggingOptions;
@@ -35,8 +34,6 @@ import com.google.cloud.logging.Severity;
 import com.google.cloud.logging.Synchronicity;
 import com.google.common.collect.ImmutableMap;
 import com.google.logging.v2.LogName;
-import com.google.protobuf.ListValue;
-import com.google.protobuf.Value;
 import java.util.Iterator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -85,24 +82,6 @@ public class ITJulLoggerTest extends BaseSystemTest {
     assertThat(entry.getOperation()).isNull();
     assertThat(entry.getInsertId()).isNotNull();
     assertThat(entry.getTimestamp()).isNotNull();
-    assertThat(iterator.hasNext()).isTrue();
-    entry = iterator.next();
-    ListValue infoList =
-        entry
-            .<Payload.JsonPayload>getPayload()
-            .getData()
-            .getFieldsOrThrow(Instrumentation.DIAGNOSTIC_INFO_KEY)
-            .getStructValue()
-            .getFieldsOrThrow(Instrumentation.INSTRUMENTATION_SOURCE_KEY)
-            .getListValue();
-    for (Value val : infoList.getValuesList()) {
-      assertThat(
-              val.getStructValue()
-                  .getFieldsOrThrow(Instrumentation.INSTRUMENTATION_NAME_KEY)
-                  .getStringValue()
-                  .startsWith(Instrumentation.JAVA_LIBRARY_NAME_PREFIX))
-          .isTrue();
-    }
     logger.removeHandler(handler);
   }
 


### PR DESCRIPTION
This feature provides an ability to log extra entry with diagnostics structure which contains logging library information. Such entry is logged only once when first entry is written by a process using logging library.

Fixes #[978](https://github.com/googleapis/java-logging/issues/978), [751](https://github.com/googleapis/java-logging/issues/751) 🦕
