### PR TITLE
fix: Update the stub to avoid the deprecated *Map method

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,20 +51,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.0.0')
+implementation platform('com.google.cloud:libraries-bom:26.1.0')
 
 implementation 'com.google.cloud:google-cloud-logging'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-logging:3.10.0'
+implementation 'com.google.cloud:google-cloud-logging:3.10.2'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.10.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.10.2"
 ```
 
 ## Authentication

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
@@ -331,7 +331,7 @@ public class LoggingServiceV2StubSettings extends StubSettings<LoggingServiceV2S
             @Override
             public PartitionKey getBatchPartitionKey(WriteLogEntriesRequest request) {
               return new PartitionKey(
-                  request.getLogName(), request.getResource(), request.getLabels());
+                  request.getLogName(), request.getResource(), request.getLabelsMap());
             }
 
             @Override


### PR DESCRIPTION
Fixes #1001

This could potentially also be fixed by regenerating the stub. Figured we might put this in ahead of that... it can be safely overwritten the next time someone runs the generator.