### PR TITLE
fix: Make LoggingHandler.logEntryFor extensible

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,20 +51,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.0.0')
+implementation platform('com.google.cloud:libraries-bom:26.1.0')
 
 implementation 'com.google.cloud:google-cloud-logging'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-logging:3.10.0'
+implementation 'com.google.cloud:google-cloud-logging:3.10.2'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.10.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.10.2"
 ```
 
 ## Authentication

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingHandler.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingHandler.java
@@ -305,7 +305,7 @@ public class LoggingHandler extends Handler {
     }
     LogEntry logEntry;
     try {
-      logEntry = logEntryFor(record);
+      logEntry = logEntryFor(record).build();
     } catch (Exception ex) {
       getErrorManager().error(null, ex, ErrorManager.FORMAT_FAILURE);
       return;
@@ -343,7 +343,7 @@ public class LoggingHandler extends Handler {
     return null;
   }
 
-  private LogEntry logEntryFor(LogRecord record) throws Exception {
+  protected LogEntry.Builder logEntryFor(LogRecord record) throws Exception {
     String payload = getFormatter().format(record);
     Level level = record.getLevel();
     LogEntry.Builder builder =
@@ -360,7 +360,7 @@ public class LoggingHandler extends Handler {
     for (LoggingEnhancer enhancer : enhancers) {
       enhancer.enhanceLogEntry(builder);
     }
-    return builder.build();
+    return builder;
   }
 
   @Override


### PR DESCRIPTION
This is a stopgap solution suggested by minherz@ in #747. The long-term fix is #32 but that seems like it could take some time (it's been open 3 years and is pending a major version bump).

This enables us to enhance the `c.g.cloud.logging.LogEntry` in ways that require access to the original `java.util.logging.LogRecord`, e.g.:

 * Setting `SourceLocation` using extra, more accurate context the Google Flogger library captures (on a subclass of the JUL `LogRecord`),
 * Recording `logRecord.getThreadID`,
 * Recording exception name explicitly from `record.getThrown()`,
 * etc