### PR TITLE
chore: added extra variables to each kokoro config

### DIFF
--- a/.kokoro/continuous/common.cfg
+++ b/.kokoro/continuous/common.cfg
@@ -23,3 +23,17 @@ env_vars: {
   key: "JOB_TYPE"
   value: "test"
 }
+
+# add labels to help with testgrid filtering
+env_vars: {
+    key: "PRODUCT_AREA_LABEL"
+    value: "observability"
+}
+env_vars: {
+    key: "PRODUCT_LABEL"
+    value: "logging"
+}
+env_vars: {
+    key: "LANGUAGE_LABEL"
+    value: "java"
+}

--- a/.kokoro/nightly/common.cfg
+++ b/.kokoro/nightly/common.cfg
@@ -23,3 +23,17 @@ env_vars: {
   key: "JOB_TYPE"
   value: "test"
 }
+
+# add labels to help with testgrid filtering
+env_vars: {
+    key: "PRODUCT_AREA_LABEL"
+    value: "observability"
+}
+env_vars: {
+    key: "PRODUCT_LABEL"
+    value: "logging"
+}
+env_vars: {
+    key: "LANGUAGE_LABEL"
+    value: "java"
+}

--- a/.kokoro/presubmit/common.cfg
+++ b/.kokoro/presubmit/common.cfg
@@ -32,3 +32,17 @@ before_action {
     }
   }
 }
+
+# add labels to help with testgrid filtering
+env_vars: {
+    key: "PRODUCT_AREA_LABEL"
+    value: "observability"
+}
+env_vars: {
+    key: "PRODUCT_LABEL"
+    value: "logging"
+}
+env_vars: {
+    key: "LANGUAGE_LABEL"
+    value: "java"
+}

--- a/.kokoro/release/common.cfg
+++ b/.kokoro/release/common.cfg
@@ -47,3 +47,17 @@ before_action {
     }
   }
 }
+
+# add labels to help with testgrid filtering
+env_vars: {
+    key: "PRODUCT_AREA_LABEL"
+    value: "observability"
+}
+env_vars: {
+    key: "PRODUCT_LABEL"
+    value: "logging"
+}
+env_vars: {
+    key: "LANGUAGE_LABEL"
+    value: "java"
+}


### PR DESCRIPTION
This PR adds extra labels to the kokoro tests to make filtering easier for our test dashboards. It adds the following labels:

type: observability
product: logging
language: java
