### PR TITLE
deps: use error_prone_annotation via shared deps

### DIFF
--- a/google-cloud-logging/pom.xml
+++ b/google-cloud-logging/pom.xml
@@ -98,7 +98,6 @@
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
-      <version>2.15.0</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
Declaring the error_prone_annotation version fails consistency check in downstream repository:

https://github.com/googleapis/java-logging-logback/pull/829#issuecomment-1230501397

Reading https://github.com/googleapis/java-logging/issues/1009, it shouldn't need the independent version declared here.