### PR TITLE
chore(tests): upgrade environment test script from python3.6

### DIFF
--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -49,11 +49,11 @@ gcloud config set compute/zone us-central1-b
 gcloud auth configure-docker -q
 
 # Remove old nox
-python3.6 -m pip uninstall --yes --quiet nox-automation
+python3 -m pip uninstall --yes --quiet nox-automation
 
 # Install nox
-python3.6 -m pip install --upgrade --quiet nox
-python3.6 -m nox --version
+python3 -m pip install --upgrade --quiet nox
+python3 -m nox --version
 
 # Install kubectl
 if [[ "${ENVIRONMENT}" == "kubernetes" ]]; then
@@ -71,7 +71,7 @@ echo $ENVCTL_ID
 
 # Run the specified environment test
 set +e
-python3.6 -m nox --session "tests(language='java', platform='$ENVIRONMENT')"
+python3 -m nox --session "tests(language='java', platform='$ENVIRONMENT')"
 TEST_STATUS_CODE=$?
 
 # destroy resources

--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -26,6 +26,7 @@ fi
 
 # make sure submodule is up to date
 cd "$PROJECT_ROOT"
+git config --global --add safe.directory '*'
 git submodule update --init --recursive
 cd "${PROJECT_ROOT}/env-tests-logging"
 


### PR DESCRIPTION
The environment tests are currently failing due to using Python3.6, which is no longer supported. This PR changes calls to Python3.6 to Python3, which is still supported in the test container


Also marks all directories on the container as safe to address the following error:

```
fatal: detected dubious ownership in repository at '/tmpfs/src/github/java-logging'
```