### PR TITLE
feat: Apply Google style recommendations

### DIFF
--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
@@ -54,7 +54,9 @@ public final class Instrumentation {
   public static Tuple<Boolean, Iterable<LogEntry>> populateInstrumentationInfo(
       Iterable<LogEntry> logEntries) {
     boolean isWritten = setInstrumentationStatus(true);
-    if (isWritten) return Tuple.of(false, logEntries);
+    if (isWritten) {
+      return Tuple.of(false, logEntries);
+    }
     List<LogEntry> entries = new ArrayList<>();
 
     for (LogEntry logEntry : logEntries) {
@@ -97,7 +99,9 @@ public final class Instrumentation {
    *     true
    */
   public static WriteOption @Nullable [] addPartialSuccessOption(WriteOption[] options) {
-    if (options == null) return options;
+    if (options == null) {
+      return options;
+    }
     List<WriteOption> writeOptions = new ArrayList<>();
     Collections.addAll(writeOptions, options);
     // Make sure we remove all partial success flags if any exist
@@ -146,8 +150,9 @@ public final class Instrumentation {
 
   private static ListValue generateLibrariesList(
       String libraryName, String libraryVersion, ListValue existingLibraryList) {
-    if (Strings.isNullOrEmpty(libraryName) || !libraryName.startsWith(JAVA_LIBRARY_NAME_PREFIX))
+    if (Strings.isNullOrEmpty(libraryName) || !libraryName.startsWith(JAVA_LIBRARY_NAME_PREFIX)) {
       libraryName = JAVA_LIBRARY_NAME_PREFIX;
+    }
     if (Strings.isNullOrEmpty(libraryVersion)) {
       libraryVersion = getLibraryVersion(Instrumentation.class);
     }
@@ -161,14 +166,21 @@ public final class Instrumentation {
           try {
             String name =
                 val.getStructValue().getFieldsOrThrow(INSTRUMENTATION_NAME_KEY).getStringValue();
-            if (Strings.isNullOrEmpty(name) || !name.startsWith(JAVA_LIBRARY_NAME_PREFIX)) continue;
+            if (Strings.isNullOrEmpty(name) || !name.startsWith(JAVA_LIBRARY_NAME_PREFIX)) {
+              continue;
+            }
             String version =
                 val.getStructValue().getFieldsOrThrow(INSTRUMENTATION_VERSION_KEY).getStringValue();
-            if (Strings.isNullOrEmpty(version)) continue;
+            if (Strings.isNullOrEmpty(version)) {
+              continue;
+            }
             libraryList.addValues(
                 Value.newBuilder().setStructValue(createInfoStruct(name, version)).build());
-            if (libraryList.getValuesCount() == MAX_DIAGNOSTIC_ENTIES) break;
+            if (libraryList.getValuesCount() == MAX_DIAGNOSTIC_ENTIES) {
+              break;
+            }
           } catch (RuntimeException ex) {
+            System.err.println("ERROR: unexpected exception in generateLibrariesList: " + ex);
           }
         }
       }
@@ -194,7 +206,9 @@ public final class Instrumentation {
    * @return The value of the flag before it was set.
    */
   static boolean setInstrumentationStatus(boolean value) {
-    if (instrumentationAdded == value) return instrumentationAdded;
+    if (instrumentationAdded == value) {
+      return instrumentationAdded;
+    }
     synchronized (instrumentationLock) {
       boolean current = instrumentationAdded;
       instrumentationAdded = value;
@@ -211,12 +225,16 @@ public final class Instrumentation {
    */
   public static String getLibraryVersion(Class<?> libraryClass) {
     String libraryVersion = GaxProperties.getLibraryVersion(libraryClass);
-    if (Strings.isNullOrEmpty(libraryVersion)) libraryVersion = DEFAULT_INSTRUMENTATION_VERSION;
+    if (Strings.isNullOrEmpty(libraryVersion)) {
+      libraryVersion = DEFAULT_INSTRUMENTATION_VERSION;
+    }
     return libraryVersion;
   }
 
   private static String truncateValue(String value) {
-    if (Strings.isNullOrEmpty(value) || value.length() < MAX_DIAGNOSTIC_VALUE_LENGTH) return value;
+    if (Strings.isNullOrEmpty(value) || value.length() < MAX_DIAGNOSTIC_VALUE_LENGTH) {
+      return value;
+    }
     return value.substring(0, MAX_DIAGNOSTIC_VALUE_LENGTH) + "*";
   }
 

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
@@ -339,6 +339,46 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
   Sink create(SinkInfo sink);
 
   /**
+   * Creates a new metric.
+   *
+   * <p>Example of creating a metric for logs with severity higher or equal to ERROR.
+   *
+   * <pre>
+   * {
+   *   &#64;code
+   *   String metricName = "my_metric_name";
+   *   MetricInfo metricInfo = MetricInfo.of(metricName, "severity>=ERROR");
+   *   Metric metric = logging.create(metricInfo);
+   * }
+   * </pre>
+   *
+   * @return the created metric
+   * @throws LoggingException upon failure
+   */
+  Metric create(MetricInfo metric);
+
+  /**
+   * Creates a new exclusion in a specified parent resource. Only log entries belonging to that
+   * resource can be excluded. You can have up to 10 exclusions in a resource.
+   *
+   * <p>Example of creating the exclusion:
+   *
+   * <pre>
+   * {
+   *   &#64;code
+   *   String exclusionName = "my_exclusion_name";
+   *   Exclusion exclusion = Exclusion.of(exclusionName,
+   *       "resource.type=gcs_bucket severity<ERROR sample(insertId, 0.99)");
+   *   Exclusion exclusion = logging.create(exclusion);
+   * }
+   * </pre>
+   *
+   * @return the created exclusion
+   * @throws LoggingException upon failure
+   */
+  Exclusion create(Exclusion exclusion);
+
+  /**
    * Sends a request for creating a sink. This method returns a {@code ApiFuture} object to consume
    * the result. {@link ApiFuture#get()} returns the created sink.
    *
@@ -358,6 +398,45 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
    * </pre>
    */
   ApiFuture<Sink> createAsync(SinkInfo sink);
+
+  /**
+   * Sends a request for creating a metric. This method returns a {@code ApiFuture} object to
+   * consume the result. {@link ApiFuture#get()} returns the created metric.
+   *
+   * <p>Example of asynchronously creating a metric for logs with severity higher or equal to ERROR.
+   *
+   * <pre>
+   * {
+   *   &#64;code
+   *   String metricName = "my_metric_name";
+   *   MetricInfo metricInfo = MetricInfo.of(metricName, "severity>=ERROR");
+   *   ApiFuture<Metric> future = logging.createAsync(metricInfo);
+   *   // ...
+   *   Metric metric = future.get();
+   * }
+   * </pre>
+   */
+  ApiFuture<Metric> createAsync(MetricInfo metric);
+
+  /**
+   * Sends a request to create the exclusion. This method returns an {@code ApiFuture} object to
+   * consume the result. {@link ApiFuture#get()} returns the created exclusion.
+   *
+   * <p>Example of asynchronously creating the exclusion:
+   *
+   * <pre>
+   * {
+   *   &#64;code
+   *   String exclusionName = "my_exclusion_name";
+   *   Exclusion exclusion = Exclusion.of(exclusionName,
+   *       "resource.type=gcs_bucket severity<ERROR sample(insertId, 0.99)");
+   *   ApiFuture<Exclusion> future = logging.createAsync(exclusion);
+   *   // ...
+   *   Exclusion exclusion = future.get();
+   * }
+   * </pre>
+   */
+  ApiFuture<Exclusion> createAsync(Exclusion exclusion);
 
   /**
    * Updates a sink or creates one if it does not exist.
@@ -381,6 +460,47 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
   Sink update(SinkInfo sink);
 
   /**
+   * Updates a metric or creates one if it does not exist.
+   *
+   * <p>Example of updating a metric.
+   *
+   * <pre>
+   * {
+   *   &#64;code
+   *   String metricName = "my_metric_name";
+   *   MetricInfo metricInfo = MetricInfo.newBuilder(metricName, "severity>=ERROR").setDescription("new description")
+   *       .build();
+   *   Metric metric = logging.update(metricInfo);
+   * }
+   * </pre>
+   *
+   * @return the created metric
+   * @throws LoggingException upon failure
+   */
+  Metric update(MetricInfo metric);
+
+  /**
+   * Updates one or more properties of an existing exclusion.
+   *
+   * <p>Example of updating the exclusion:
+   *
+   * <pre>
+   * {
+   *   &#64;code
+   *   String exclusionName = "my_exclusion_name";
+   *   Exclusion exclusion = Exclusion
+   *       .newBuilder(exclusionName, "resource.type=gcs_bucket severity<ERROR sample(insertId, 0.99)")
+   *       .setDescription("new description").setIsDisabled(false).build();
+   *   Exclusion exclusion = logging.update(exclusion);
+   * }
+   * </pre>
+   *
+   * @return the updated exclusion
+   * @throws LoggingException upon failure
+   */
+  Exclusion update(Exclusion exclusion);
+
+  /**
    * Sends a request for updating a sink (or creating it, if it does not exist). This method returns
    * a {@code ApiFuture} object to consume the result. {@link ApiFuture#get()} returns the
    * updated/created sink or {@code null} if not found.
@@ -401,6 +521,49 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
    * </pre>
    */
   ApiFuture<Sink> updateAsync(SinkInfo sink);
+
+  /**
+   * Sends a request for updating a metric (or creating it, if it does not exist). This method
+   * returns a {@code ApiFuture} object to consume the result. {@link ApiFuture#get()} returns the
+   * updated/created metric or {@code null} if not found.
+   *
+   * <p>Example of asynchronously updating a metric.
+   *
+   * <pre>
+   * {
+   *   &#64;code
+   *   String metricName = "my_metric_name";
+   *   MetricInfo metricInfo = MetricInfo.newBuilder(metricName, "severity>=ERROR").setDescription("new description")
+   *       .build();
+   *   ApiFuture<Metric> future = logging.updateAsync(metricInfo);
+   *   // ...
+   *   Metric metric = future.get();
+   * }
+   * </pre>
+   */
+  ApiFuture<Metric> updateAsync(MetricInfo metric);
+
+  /**
+   * Sends a request to change one or more properties of an existing exclusion. This method returns
+   * an {@code ApiFuture} object to consume the result. {@link ApiFuture#get()} returns the updated
+   * exclusion or {@code null} if not found.
+   *
+   * <p>Example of asynchronous exclusion update:
+   *
+   * <pre>
+   * {
+   *   &#64;code
+   *   String exclusionName = "my_exclusion_name";
+   *   Exclusion exclusion = Exclusion
+   *       .newBuilder(exclusionName, "resource.type=gcs_bucket severity<ERROR sample(insertId, 0.99)")
+   *       .setDescription("new description").setIsDisabled(false).build();
+   *   ApiFuture<Exclusion> future = logging.updateAsync(exclusion);
+   *   // ...
+   *   Exclusion exclusion = future.get();
+   * }
+   * </pre>
+   */
+  ApiFuture<Exclusion> updateAsync(Exclusion exclusion);
 
   /**
    * Returns the requested sink or {@code null} if not found.
@@ -737,85 +900,6 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
       ListOption... options);
 
   /**
-   * Creates a new metric.
-   *
-   * <p>Example of creating a metric for logs with severity higher or equal to ERROR.
-   *
-   * <pre>
-   * {
-   *   &#64;code
-   *   String metricName = "my_metric_name";
-   *   MetricInfo metricInfo = MetricInfo.of(metricName, "severity>=ERROR");
-   *   Metric metric = logging.create(metricInfo);
-   * }
-   * </pre>
-   *
-   * @return the created metric
-   * @throws LoggingException upon failure
-   */
-  Metric create(MetricInfo metric);
-
-  /**
-   * Sends a request for creating a metric. This method returns a {@code ApiFuture} object to
-   * consume the result. {@link ApiFuture#get()} returns the created metric.
-   *
-   * <p>Example of asynchronously creating a metric for logs with severity higher or equal to ERROR.
-   *
-   * <pre>
-   * {
-   *   &#64;code
-   *   String metricName = "my_metric_name";
-   *   MetricInfo metricInfo = MetricInfo.of(metricName, "severity>=ERROR");
-   *   ApiFuture<Metric> future = logging.createAsync(metricInfo);
-   *   // ...
-   *   Metric metric = future.get();
-   * }
-   * </pre>
-   */
-  ApiFuture<Metric> createAsync(MetricInfo metric);
-
-  /**
-   * Updates a metric or creates one if it does not exist.
-   *
-   * <p>Example of updating a metric.
-   *
-   * <pre>
-   * {
-   *   &#64;code
-   *   String metricName = "my_metric_name";
-   *   MetricInfo metricInfo = MetricInfo.newBuilder(metricName, "severity>=ERROR").setDescription("new description")
-   *       .build();
-   *   Metric metric = logging.update(metricInfo);
-   * }
-   * </pre>
-   *
-   * @return the created metric
-   * @throws LoggingException upon failure
-   */
-  Metric update(MetricInfo metric);
-
-  /**
-   * Sends a request for updating a metric (or creating it, if it does not exist). This method
-   * returns a {@code ApiFuture} object to consume the result. {@link ApiFuture#get()} returns the
-   * updated/created metric or {@code null} if not found.
-   *
-   * <p>Example of asynchronously updating a metric.
-   *
-   * <pre>
-   * {
-   *   &#64;code
-   *   String metricName = "my_metric_name";
-   *   MetricInfo metricInfo = MetricInfo.newBuilder(metricName, "severity>=ERROR").setDescription("new description")
-   *       .build();
-   *   ApiFuture<Metric> future = logging.updateAsync(metricInfo);
-   *   // ...
-   *   Metric metric = future.get();
-   * }
-   * </pre>
-   */
-  ApiFuture<Metric> updateAsync(MetricInfo metric);
-
-  /**
    * Returns the requested metric or {@code null} if not found.
    *
    * <p>Example of getting a metric.
@@ -949,47 +1033,6 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
   ApiFuture<Boolean> deleteMetricAsync(String metric);
 
   /**
-   * Creates a new exclusion in a specified parent resource. Only log entries belonging to that
-   * resource can be excluded. You can have up to 10 exclusions in a resource.
-   *
-   * <p>Example of creating the exclusion:
-   *
-   * <pre>
-   * {
-   *   &#64;code
-   *   String exclusionName = "my_exclusion_name";
-   *   Exclusion exclusion = Exclusion.of(exclusionName,
-   *       "resource.type=gcs_bucket severity<ERROR sample(insertId, 0.99)");
-   *   Exclusion exclusion = logging.create(exclusion);
-   * }
-   * </pre>
-   *
-   * @return the created exclusion
-   * @throws LoggingException upon failure
-   */
-  Exclusion create(Exclusion exclusion);
-
-  /**
-   * Sends a request to create the exclusion. This method returns an {@code ApiFuture} object to
-   * consume the result. {@link ApiFuture#get()} returns the created exclusion.
-   *
-   * <p>Example of asynchronously creating the exclusion:
-   *
-   * <pre>
-   * {
-   *   &#64;code
-   *   String exclusionName = "my_exclusion_name";
-   *   Exclusion exclusion = Exclusion.of(exclusionName,
-   *       "resource.type=gcs_bucket severity<ERROR sample(insertId, 0.99)");
-   *   ApiFuture<Exclusion> future = logging.createAsync(exclusion);
-   *   // ...
-   *   Exclusion exclusion = future.get();
-   * }
-   * </pre>
-   */
-  ApiFuture<Exclusion> createAsync(Exclusion exclusion);
-
-  /**
    * Gets the description of an exclusion or {@code null} if not found.
    *
    * <p>Example of getting the description of an exclusion:
@@ -1032,49 +1075,6 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
    * @throws LoggingException upon failure
    */
   ApiFuture<Exclusion> getExclusionAsync(String exclusion);
-
-  /**
-   * Updates one or more properties of an existing exclusion.
-   *
-   * <p>Example of updating the exclusion:
-   *
-   * <pre>
-   * {
-   *   &#64;code
-   *   String exclusionName = "my_exclusion_name";
-   *   Exclusion exclusion = Exclusion
-   *       .newBuilder(exclusionName, "resource.type=gcs_bucket severity<ERROR sample(insertId, 0.99)")
-   *       .setDescription("new description").setIsDisabled(false).build();
-   *   Exclusion exclusion = logging.update(exclusion);
-   * }
-   * </pre>
-   *
-   * @return the updated exclusion
-   * @throws LoggingException upon failure
-   */
-  Exclusion update(Exclusion exclusion);
-
-  /**
-   * Sends a request to change one or more properties of an existing exclusion. This method returns
-   * an {@code ApiFuture} object to consume the result. {@link ApiFuture#get()} returns the updated
-   * exclusion or {@code null} if not found.
-   *
-   * <p>Example of asynchronous exclusion update:
-   *
-   * <pre>
-   * {
-   *   &#64;code
-   *   String exclusionName = "my_exclusion_name";
-   *   Exclusion exclusion = Exclusion
-   *       .newBuilder(exclusionName, "resource.type=gcs_bucket severity<ERROR sample(insertId, 0.99)")
-   *       .setDescription("new description").setIsDisabled(false).build();
-   *   ApiFuture<Exclusion> future = logging.updateAsync(exclusion);
-   *   // ...
-   *   Exclusion exclusion = future.get();
-   * }
-   * </pre>
-   */
-  ApiFuture<Exclusion> updateAsync(Exclusion exclusion);
 
   /**
    * Deletes the requested exclusion.

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingConfig.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingConfig.java
@@ -104,11 +104,9 @@ class LoggingConfig {
       List<LoggingEnhancer> enhancers = new ArrayList<>();
       if (list != null) {
         Iterable<String> items = Splitter.on(',').split(list);
-        for (String e_name : items) {
+        for (String eName : items) {
           Class<? extends LoggingEnhancer> clazz =
-              ClassLoader.getSystemClassLoader()
-                  .loadClass(e_name)
-                  .asSubclass(LoggingEnhancer.class);
+              ClassLoader.getSystemClassLoader().loadClass(eName).asSubclass(LoggingEnhancer.class);
           enhancers.add(clazz.getDeclaredConstructor().newInstance());
         }
       }
@@ -133,6 +131,10 @@ class LoggingConfig {
 
   private String getProperty(String name, String defaultValue) {
     return firstNonNull(getProperty(name), defaultValue);
+  }
+
+  private String getProperty(String propertyName) {
+    return manager.getProperty(className + "." + propertyName);
   }
 
   private Boolean getBooleanProperty(String name, Boolean defaultValue) {
@@ -180,9 +182,5 @@ class LoggingConfig {
       // If we cannot create the filter we fall back to default value
     }
     return defaultValue;
-  }
-
-  private String getProperty(String propertyName) {
-    return manager.getProperty(className + "." + propertyName);
   }
 }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/ResourceTypeEnvironmentGetter.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/ResourceTypeEnvironmentGetter.java
@@ -16,9 +16,6 @@
 
 package com.google.cloud.logging;
 
-import com.google.cloud.MetadataConfig;
-import org.jspecify.nullness.Nullable;
-
 public interface ResourceTypeEnvironmentGetter {
 
   /**
@@ -40,23 +37,4 @@ public interface ResourceTypeEnvironmentGetter {
    * @see MetadataConfig#getAttribute()
    */
   String getAttribute(String name);
-}
-
-final class ResourceTypeEnvironmentGetterImpl implements ResourceTypeEnvironmentGetter {
-
-  @Override
-  public @Nullable String getEnv(String name) {
-    // handle exception thrown if a security manager exists and blocks access to the
-    // process environment
-    try {
-      return System.getenv(name);
-    } catch (SecurityException ex) {
-      return null;
-    }
-  }
-
-  @Override
-  public String getAttribute(String name) {
-    return MetadataConfig.getAttribute(name);
-  }
 }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/ResourceTypeEnvironmentGetterImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/ResourceTypeEnvironmentGetterImpl.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging;
+
+import com.google.cloud.MetadataConfig;
+import org.jspecify.nullness.Nullable;
+
+final class ResourceTypeEnvironmentGetterImpl implements ResourceTypeEnvironmentGetter {
+
+  @Override
+  public @Nullable String getEnv(String name) {
+    // handle exception thrown if a security manager exists and blocks access to the
+    // process environment
+    try {
+      return System.getenv(name);
+    } catch (SecurityException ex) {
+      return null;
+    }
+  }
+
+  @Override
+  public String getAttribute(String name) {
+    return MetadataConfig.getAttribute(name);
+  }
+}

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/InstrumentationTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/InstrumentationTest.java
@@ -68,11 +68,11 @@ public class InstrumentationTest {
   @Test
   public void testInstrumentationUpdated() {
     Instrumentation.setInstrumentationStatus(false);
-    LogEntry json_entry =
+    LogEntry jsonEntry =
         LogEntry.newBuilder(generateInstrumentationPayload(JAVA_OTHER_NAME, JAVA_OTHER_VERSION))
             .build();
     verifyEntries(
-        Instrumentation.populateInstrumentationInfo(ImmutableList.of(json_entry)),
+        Instrumentation.populateInstrumentationInfo(ImmutableList.of(jsonEntry)),
         0,
         1,
         new HashSet<>(Arrays.asList(Instrumentation.JAVA_LIBRARY_NAME_PREFIX, JAVA_OTHER_NAME)),
@@ -84,11 +84,11 @@ public class InstrumentationTest {
   @Test
   public void testInvalidInstrumentationRemoved() {
     Instrumentation.setInstrumentationStatus(false);
-    LogEntry json_entry =
+    LogEntry jsonEntry =
         LogEntry.newBuilder(generateInstrumentationPayload(JAVA_INVALID_NAME, JAVA_OTHER_VERSION))
             .build();
     verifyEntries(
-        Instrumentation.populateInstrumentationInfo(ImmutableList.of(json_entry)),
+        Instrumentation.populateInstrumentationInfo(ImmutableList.of(jsonEntry)),
         0,
         1,
         new HashSet<>(Arrays.asList(Instrumentation.JAVA_LIBRARY_NAME_PREFIX)),
@@ -97,15 +97,15 @@ public class InstrumentationTest {
 
   public static JsonPayload generateInstrumentationPayload(
       String libraryName, String libraryVersion) {
-    Map<String, Object> json_data = new HashMap<>();
-    Map<String, Object> instrumentation_data = new HashMap<>();
+    Map<String, Object> jsonData = new HashMap<>();
+    Map<String, Object> instrumentationData = new HashMap<>();
     Map<String, Object> info = new HashMap<>();
     info.put(Instrumentation.INSTRUMENTATION_NAME_KEY, libraryName);
     info.put(Instrumentation.INSTRUMENTATION_VERSION_KEY, libraryVersion);
     ImmutableList<Object> list = ImmutableList.<Object>of(info);
-    instrumentation_data.put(Instrumentation.INSTRUMENTATION_SOURCE_KEY, list);
-    json_data.put(Instrumentation.DIAGNOSTIC_INFO_KEY, instrumentation_data);
-    return JsonPayload.of(json_data);
+    instrumentationData.put(Instrumentation.INSTRUMENTATION_SOURCE_KEY, list);
+    jsonData.put(Instrumentation.DIAGNOSTIC_INFO_KEY, instrumentationData);
+    return JsonPayload.of(jsonData);
   }
 
   private static void verifyEntries(

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LogEntryTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LogEntryTest.java
@@ -36,7 +36,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-@SuppressWarnings("deprecation")
+@SuppressWarnings("deprecation") // We're testing our own deprecated Builder methods
 public class LogEntryTest {
 
   private static final String LOG_NAME = "syslog";
@@ -382,11 +382,11 @@ public class LogEntryTest {
   @Test
   public void testStructureLogPresentations() {
     for (int i = 0; i < TEST_LOG_ENTRIES.length; i++) {
-      String structured_log = TEST_LOG_ENTRIES[i].toStructuredJsonString();
+      String structuredLog = TEST_LOG_ENTRIES[i].toStructuredJsonString();
 
       assertEquals(
           JsonParser.parseString(EXPECTED_STRUCTURED_LOGS[i]),
-          JsonParser.parseString(structured_log));
+          JsonParser.parseString(structuredLog));
     }
   }
 

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.logging;
 
-import static com.google.cloud.logging.SinkInfo.VersionFormat;
 import static com.google.protobuf.util.Timestamps.fromMillis;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertArrayEquals;
@@ -40,6 +39,7 @@ import com.google.cloud.logging.Logging.SortingField;
 import com.google.cloud.logging.Logging.WriteOption;
 import com.google.cloud.logging.Payload.StringPayload;
 import com.google.cloud.logging.SinkInfo.Destination;
+import com.google.cloud.logging.SinkInfo.VersionFormat;
 import com.google.cloud.logging.spi.LoggingRpcFactory;
 import com.google.cloud.logging.spi.v2.LoggingRpc;
 import com.google.common.collect.ImmutableList;
@@ -348,7 +348,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testGetSink_Null() {
+  public void testGetSink_null() {
     ApiFuture<LogSink> response = ApiFutures.immediateFuture(null);
     GetSinkRequest request = GetSinkRequest.newBuilder().setSinkName(SINK_NAME_PB).build();
     EasyMock.expect(loggingRpcMock.get(request)).andReturn(response);
@@ -370,7 +370,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testGetSinkAsync_Null() throws ExecutionException, InterruptedException {
+  public void testGetSinkAsync_null() throws ExecutionException, InterruptedException {
     ApiFuture<LogSink> response = ApiFutures.immediateFuture(null);
     GetSinkRequest request = GetSinkRequest.newBuilder().setSinkName(SINK_NAME_PB).build();
     EasyMock.expect(loggingRpcMock.get(request)).andReturn(response);
@@ -390,7 +390,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testDeleteSink_Null() {
+  public void testDeleteSink_null() {
     DeleteSinkRequest request = DeleteSinkRequest.newBuilder().setSinkName(SINK_NAME_PB).build();
     ApiFuture<Empty> response = ApiFutures.immediateFuture(null);
     EasyMock.expect(loggingRpcMock.delete(request)).andReturn(response);
@@ -410,7 +410,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testDeleteSinkAsync_Null() throws ExecutionException, InterruptedException {
+  public void testDeleteSinkAsync_null() throws ExecutionException, InterruptedException {
     DeleteSinkRequest request = DeleteSinkRequest.newBuilder().setSinkName(SINK_NAME_PB).build();
     ApiFuture<Empty> response = ApiFutures.immediateFuture(null);
     EasyMock.expect(loggingRpcMock.delete(request)).andReturn(response);
@@ -704,7 +704,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testGetMetric_Null() {
+  public void testGetMetric_null() {
     ApiFuture<LogMetric> response = ApiFutures.immediateFuture(null);
     GetLogMetricRequest request =
         GetLogMetricRequest.newBuilder().setMetricName(METRIC_NAME_PB).build();
@@ -728,7 +728,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testGetMetricAsync_Null() throws ExecutionException, InterruptedException {
+  public void testGetMetricAsync_null() throws ExecutionException, InterruptedException {
     ApiFuture<LogMetric> response = ApiFutures.immediateFuture(null);
     GetLogMetricRequest request =
         GetLogMetricRequest.newBuilder().setMetricName(METRIC_NAME_PB).build();
@@ -750,7 +750,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testDeleteMetric_Null() {
+  public void testDeleteMetric_null() {
     DeleteLogMetricRequest request =
         DeleteLogMetricRequest.newBuilder().setMetricName(METRIC_NAME_PB).build();
     ApiFuture<Empty> response = ApiFutures.immediateFuture(null);
@@ -772,7 +772,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testDeleteMetricAsync_Null() throws ExecutionException, InterruptedException {
+  public void testDeleteMetricAsync_null() throws ExecutionException, InterruptedException {
     DeleteLogMetricRequest request =
         DeleteLogMetricRequest.newBuilder().setMetricName(METRIC_NAME_PB).build();
     ApiFuture<Empty> response = ApiFutures.immediateFuture(null);
@@ -1065,7 +1065,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testGetExclusion_Null() {
+  public void testGetExclusion_null() {
     ApiFuture<LogExclusion> response = ApiFutures.immediateFuture(null);
     GetExclusionRequest request =
         GetExclusionRequest.newBuilder().setName(EXCLUSION_NAME_PB).build();
@@ -1094,7 +1094,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testGetExclusionAsync_Null() throws ExecutionException, InterruptedException {
+  public void testGetExclusionAsync_null() throws ExecutionException, InterruptedException {
     ApiFuture<LogExclusion> response = ApiFutures.immediateFuture(null);
     GetExclusionRequest request =
         GetExclusionRequest.newBuilder().setName(EXCLUSION_NAME_PB).build();
@@ -1157,7 +1157,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testDeleteExclusion_Null() {
+  public void testDeleteExclusion_null() {
     DeleteExclusionRequest request =
         DeleteExclusionRequest.newBuilder().setName(EXCLUSION_NAME_PB).build();
     ApiFuture<Empty> response = ApiFutures.immediateFuture(null);
@@ -1179,7 +1179,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testDeleteExclusionAsync_Null() throws ExecutionException, InterruptedException {
+  public void testDeleteExclusionAsync_null() throws ExecutionException, InterruptedException {
     DeleteExclusionRequest request =
         DeleteExclusionRequest.newBuilder().setName(EXCLUSION_NAME_PB).build();
     ApiFuture<Empty> response = ApiFutures.immediateFuture(null);
@@ -1768,7 +1768,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testDeleteLog_Null() {
+  public void testDeleteLog_null() {
     DeleteLogRequest request =
         DeleteLogRequest.newBuilder().setLogName(LOG_NAME_PROJECT_PATH).build();
     EasyMock.expect(loggingRpcMock.delete(request))
@@ -1834,7 +1834,7 @@ public class LoggingImplTest {
   }
 
   @Test
-  public void testDeleteLogAsync_Null() throws ExecutionException, InterruptedException {
+  public void testDeleteLogAsync_null() throws ExecutionException, InterruptedException {
     DeleteLogRequest request =
         DeleteLogRequest.newBuilder().setLogName(LOG_NAME_PROJECT_PATH).build();
     EasyMock.expect(loggingRpcMock.delete(request))
@@ -2306,7 +2306,7 @@ public class LoggingImplTest {
 
   private void testDiagnosticInfoGeneration(boolean addPartialSuccessOption) {
     Instrumentation.setInstrumentationStatus(false);
-    LogEntry json_entry =
+    LogEntry jsonEntry =
         LogEntry.newBuilder(
                 InstrumentationTest.generateInstrumentationPayload(
                     Instrumentation.JAVA_LIBRARY_NAME_PREFIX,
@@ -2317,7 +2317,7 @@ public class LoggingImplTest {
         WriteLogEntriesRequest.newBuilder()
             .addAllEntries(
                 Iterables.transform(
-                    ImmutableList.of(LOG_ENTRY1, LOG_ENTRY2, json_entry),
+                    ImmutableList.of(LOG_ENTRY1, LOG_ENTRY2, jsonEntry),
                     LogEntry.toPbFunction(PROJECT)))
             .setPartialSuccess(true)
             .build();

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingTest.java
@@ -16,15 +16,15 @@
 
 package com.google.cloud.logging;
 
-import static com.google.cloud.logging.Logging.EntryListOption;
-import static com.google.cloud.logging.Logging.SortingField;
-import static com.google.cloud.logging.Logging.SortingOrder;
-import static com.google.cloud.logging.Logging.WriteOption;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import com.google.cloud.MonitoredResource;
+import com.google.cloud.logging.Logging.EntryListOption;
 import com.google.cloud.logging.Logging.ListOption;
+import com.google.cloud.logging.Logging.SortingField;
+import com.google.cloud.logging.Logging.SortingOrder;
+import com.google.cloud.logging.Logging.WriteOption;
 import com.google.common.collect.ImmutableMap;
 import com.google.logging.v2.ListLogEntriesRequest;
 import org.junit.Test;

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/MonitoredResourceUtilTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/MonitoredResourceUtilTest.java
@@ -59,7 +59,7 @@ public class MonitoredResourceUtilTest {
 
   @Test
   public void testResourceTypeGlobal() {
-    final ImmutableMap<String, String> ExpectedLabels =
+    final ImmutableMap<String, String> expectedLabels =
         ImmutableMap.of("project_id", MonitoredResourceUtilTest.MOCKED_PROJECT_ID);
 
     // setup
@@ -70,41 +70,41 @@ public class MonitoredResourceUtilTest {
     MonitoredResource response = MonitoredResourceUtil.getResource("", "");
     // verify
     assertEquals("global", response.getType());
-    assertEquals(ExpectedLabels, response.getLabels());
+    assertEquals(expectedLabels, response.getLabels());
   }
 
   @Test
   public void testGetResourceWithParameters() {
-    final String MyProjectId = "my-project-id";
-    final String MyResourceType = "my-resource-type";
-    final ImmutableMap<String, String> ExpectedLabels = ImmutableMap.of("project_id", MyProjectId);
+    final String myProjectId = "my-project-id";
+    final String myResourceType = "my-resource-type";
+    final ImmutableMap<String, String> expectedLabels = ImmutableMap.of("project_id", myProjectId);
 
     // setup
     replay(getterMock);
     // exercise
-    MonitoredResource response = MonitoredResourceUtil.getResource(MyProjectId, MyResourceType);
+    MonitoredResource response = MonitoredResourceUtil.getResource(myProjectId, myResourceType);
     // The above doesn't query metadata... So just to satisfy the verify stage, query it:
     getterMock.getAttribute("project/project-id");
     getterMock.getAttribute("");
     // verify
     assertEquals("my-resource-type", response.getType());
-    assertEquals(ExpectedLabels, response.getLabels());
+    assertEquals(expectedLabels, response.getLabels());
   }
 
   @Test
   public void testResourceTypeGCEInstance() {
-    final String MockedInstanceId = "1234567890abcdefg";
-    final ImmutableMap<String, String> ExpectedLabels =
+    final String mockedInstanceId = "1234567890abcdefg";
+    final ImmutableMap<String, String> expectedLabels =
         ImmutableMap.of(
             "project_id",
             MonitoredResourceUtilTest.MOCKED_PROJECT_ID,
             "instance_id",
-            MockedInstanceId,
+            mockedInstanceId,
             "zone",
             MOCKED_ZONE);
 
     // setup
-    expect(getterMock.getAttribute("instance/id")).andReturn(MockedInstanceId).anyTimes();
+    expect(getterMock.getAttribute("instance/id")).andReturn(mockedInstanceId).anyTimes();
     expect(getterMock.getAttribute("instance/preempted")).andReturn(MOCKED_NON_EMPTY).once();
     expect(getterMock.getAttribute("instance/cpu-platform")).andReturn(MOCKED_NON_EMPTY).once();
     expect(getterMock.getAttribute("instance/zone")).andReturn(MOCKED_QUALIFIED_ZONE).once();
@@ -115,7 +115,7 @@ public class MonitoredResourceUtilTest {
     MonitoredResource response = MonitoredResourceUtil.getResource("", "");
     // verify
     assertEquals("gce_instance", response.getType());
-    assertEquals(ExpectedLabels, response.getLabels());
+    assertEquals(expectedLabels, response.getLabels());
   }
 
   /**
@@ -125,36 +125,36 @@ public class MonitoredResourceUtilTest {
    */
   @Test
   public void testResourceTypeK8sContainer() {
-    final String MockedClusterName = "mocked-cluster-1";
-    final String MockedNamespaceName = "default";
-    final String MockedPodName = "mocked-pod";
-    final String MockedContainerName = "mocked-container";
-    final ImmutableMap<String, String> ExpectedLabels =
+    final String mockedClusterName = "mocked-cluster-1";
+    final String mockedNamespaceName = "default";
+    final String mockedPodName = "mocked-pod";
+    final String mockedContainerName = "mocked-container";
+    final ImmutableMap<String, String> expectedLabels =
         ImmutableMap.<String, String>builder()
             .put("project_id", MonitoredResourceUtilTest.MOCKED_PROJECT_ID)
-            .put("cluster_name", MockedClusterName)
+            .put("cluster_name", mockedClusterName)
             .put("location", MOCKED_ZONE)
-            .put("namespace_name", MockedNamespaceName)
-            .put("pod_name", MockedPodName)
-            .put("container_name", MockedContainerName)
+            .put("namespace_name", mockedNamespaceName)
+            .put("pod_name", mockedPodName)
+            .put("container_name", mockedContainerName)
             .buildOrThrow();
 
     // setup
     expect(getterMock.getAttribute("instance/attributes/cluster-name"))
-        .andReturn(MockedClusterName)
+        .andReturn(mockedClusterName)
         .times(2);
     expect(getterMock.getAttribute("instance/zone")).andReturn(MOCKED_QUALIFIED_ZONE).once();
     expect(getterMock.getAttribute(anyString())).andReturn(null).anyTimes();
-    expect(getterMock.getEnv("HOSTNAME")).andReturn(MockedPodName).anyTimes();
-    expect(getterMock.getEnv("NAMESPACE_NAME")).andReturn(MockedNamespaceName).anyTimes();
-    expect(getterMock.getEnv("CONTAINER_NAME")).andReturn(MockedContainerName).anyTimes();
+    expect(getterMock.getEnv("HOSTNAME")).andReturn(mockedPodName).anyTimes();
+    expect(getterMock.getEnv("NAMESPACE_NAME")).andReturn(mockedNamespaceName).anyTimes();
+    expect(getterMock.getEnv("CONTAINER_NAME")).andReturn(mockedContainerName).anyTimes();
     expect(getterMock.getEnv(anyString())).andReturn(null).anyTimes();
     replay(getterMock);
     // exercise
     MonitoredResource response = MonitoredResourceUtil.getResource("", "");
     // verify
     assertEquals("k8s_container", response.getType());
-    assertEquals(ExpectedLabels, response.getLabels());
+    assertEquals(expectedLabels, response.getLabels());
   }
 
   private void setupCommonGAEMocks(String mockedModuleId, String mockedVersionId) {
@@ -167,51 +167,51 @@ public class MonitoredResourceUtilTest {
 
   @Test
   public void testResourceTypeGAEStandardEnvironment() {
-    final String MockedModuleId = "mocked-module-id";
-    final String MockedVersionId = "mocked-version-id";
-    final ImmutableMap<String, String> ExpectedLabels =
+    final String mockedModuleId = "mocked-module-id";
+    final String mockedVersionId = "mocked-version-id";
+    final ImmutableMap<String, String> expectedLabels =
         ImmutableMap.of(
             "project_id",
             MonitoredResourceUtilTest.MOCKED_PROJECT_ID,
             "module_id",
-            MockedModuleId,
+            mockedModuleId,
             "version_id",
-            MockedVersionId,
+            mockedVersionId,
             "env",
             "standard",
             "zone",
             MOCKED_ZONE);
 
     // setup
-    setupCommonGAEMocks(MockedModuleId, MockedVersionId);
+    setupCommonGAEMocks(mockedModuleId, mockedVersionId);
     expect(getterMock.getAttribute(anyString())).andReturn(null).anyTimes();
     replay(getterMock);
     // exercise
     MonitoredResource response = MonitoredResourceUtil.getResource("", "");
     // verify
     assertEquals("gae_app", response.getType());
-    assertEquals(ExpectedLabels, response.getLabels());
+    assertEquals(expectedLabels, response.getLabels());
   }
 
   @Test
   public void testResourceTypeGAEFlexibleEnvironment() {
-    final String MockedModuleId = "mocked-module-id";
-    final String MockedVersionId = "mocked-version-id";
-    final ImmutableMap<String, String> ExpectedLabels =
+    final String mockedModuleId = "mocked-module-id";
+    final String mockedVersionId = "mocked-version-id";
+    final ImmutableMap<String, String> expectedLabels =
         ImmutableMap.of(
             "project_id",
             MonitoredResourceUtilTest.MOCKED_PROJECT_ID,
             "module_id",
-            MockedModuleId,
+            mockedModuleId,
             "version_id",
-            MockedVersionId,
+            mockedVersionId,
             "env",
             "flex",
             "zone",
             MOCKED_ZONE);
 
     // setup
-    setupCommonGAEMocks(MockedModuleId, MockedVersionId);
+    setupCommonGAEMocks(mockedModuleId, mockedVersionId);
     expect(getterMock.getAttribute("instance/attributes/startup-script"))
         .andReturn("/var/lib/flex/startup_script.sh")
         .once();
@@ -220,18 +220,18 @@ public class MonitoredResourceUtilTest {
     MonitoredResource response = MonitoredResourceUtil.getResource("", "");
     // verify
     assertEquals("gae_app", response.getType());
-    assertEquals(ExpectedLabels, response.getLabels());
+    assertEquals(expectedLabels, response.getLabels());
   }
 
   @Test
   public void testResourceTypeCloudFunction() {
-    final String MockedFunctionName = "mocked-function-name";
-    final ImmutableMap<String, String> ExpectedLabels =
+    final String mockedFunctionName = "mocked-function-name";
+    final ImmutableMap<String, String> expectedLabels =
         ImmutableMap.of(
             "project_id",
             MonitoredResourceUtilTest.MOCKED_PROJECT_ID,
             "function_name",
-            MockedFunctionName,
+            mockedFunctionName,
             "region",
             MOCKED_REGION);
 
@@ -240,10 +240,10 @@ public class MonitoredResourceUtilTest {
     expect(getterMock.getAttribute(anyString())).andReturn(null).anyTimes();
     expect(getterMock.getEnv("FUNCTION_SIGNATURE_TYPE")).andReturn(MOCKED_NON_EMPTY).once();
     expect(getterMock.getEnv("FUNCTION_TARGET")).andReturn(MOCKED_NON_EMPTY).once();
-    expect(getterMock.getEnv("K_SERVICE")).andReturn(MockedFunctionName).anyTimes();
-    expect(getterMock.getEnv("K_REVISION")).andReturn(MockedFunctionName + ".1").anyTimes();
+    expect(getterMock.getEnv("K_SERVICE")).andReturn(mockedFunctionName).anyTimes();
+    expect(getterMock.getEnv("K_REVISION")).andReturn(mockedFunctionName + ".1").anyTimes();
     expect(getterMock.getEnv("K_CONFIGURATION"))
-        .andReturn(MockedFunctionName + "-config")
+        .andReturn(mockedFunctionName + "-config")
         .anyTimes();
     expect(getterMock.getEnv(anyString())).andReturn(null).anyTimes();
     replay(getterMock);
@@ -251,39 +251,39 @@ public class MonitoredResourceUtilTest {
     MonitoredResource response = MonitoredResourceUtil.getResource("", "");
     // verify
     assertEquals("cloud_function", response.getType());
-    assertEquals(ExpectedLabels, response.getLabels());
+    assertEquals(expectedLabels, response.getLabels());
   }
 
   @Test
   public void testResourceTypeCloudRun() {
-    final String MockedRevisionName = "mocked-revision-name";
-    final String MockedServiceName = "mocked-service-name";
-    final String MockedConfigurationName = "mocked-config-name";
-    final ImmutableMap<String, String> ExpectedLabels =
+    final String mockedRevisionName = "mocked-revision-name";
+    final String mockedServiceName = "mocked-service-name";
+    final String mockedConfigurationName = "mocked-config-name";
+    final ImmutableMap<String, String> expectedLabels =
         ImmutableMap.of(
             "project_id",
             MonitoredResourceUtilTest.MOCKED_PROJECT_ID,
             "revision_name",
-            MockedRevisionName,
+            mockedRevisionName,
             "configuration_name",
-            MockedConfigurationName,
+            mockedConfigurationName,
             "service_name",
-            MockedServiceName,
+            mockedServiceName,
             "location",
             MOCKED_REGION);
 
     // setup
     expect(getterMock.getAttribute("instance/region")).andReturn(MOCKED_QUALIFIED_REGION).once();
     expect(getterMock.getAttribute(anyString())).andReturn(null).anyTimes();
-    expect(getterMock.getEnv("K_CONFIGURATION")).andReturn(MockedConfigurationName).times(2);
-    expect(getterMock.getEnv("K_REVISION")).andReturn(MockedRevisionName).times(2);
-    expect(getterMock.getEnv("K_SERVICE")).andReturn(MockedServiceName).anyTimes();
+    expect(getterMock.getEnv("K_CONFIGURATION")).andReturn(mockedConfigurationName).times(2);
+    expect(getterMock.getEnv("K_REVISION")).andReturn(mockedRevisionName).times(2);
+    expect(getterMock.getEnv("K_SERVICE")).andReturn(mockedServiceName).anyTimes();
     expect(getterMock.getEnv(anyString())).andReturn(null).anyTimes();
     replay(getterMock);
     // exercise
     MonitoredResource response = MonitoredResourceUtil.getResource("", "");
     // verify
     assertEquals("cloud_run_revision", response.getType());
-    assertEquals(ExpectedLabels, response.getLabels());
+    assertEquals(expectedLabels, response.getLabels());
   }
 }

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/SinkInfoTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/SinkInfoTest.java
@@ -133,7 +133,7 @@ public class SinkInfoTest {
   }
 
   @Test
-  public void testToAndFromPbDestination_NoProjectId() {
+  public void testToAndFromPbDestination_noProjectId() {
     DatasetDestination datasetDestination =
         DatasetDestination.fromPb(DatasetDestination.of("dataset").toPb("project"));
     compareDatasetDestination(DATASET_DESTINATION, datasetDestination);
@@ -208,7 +208,7 @@ public class SinkInfoTest {
   }
 
   @Test
-  public void testToAndFromPb_NoProjectId() {
+  public void testToAndFromPb_noProjectId() {
     DatasetDestination datasetDestination = DatasetDestination.of("dataset");
     SinkInfo sinkInfo =
         SinkInfo.newBuilder(NAME, DATASET_DESTINATION).setVersionFormat(VERSION).build();

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/TailLogEntriesTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/TailLogEntriesTest.java
@@ -16,12 +16,12 @@
 
 package com.google.cloud.logging;
 
-import static com.google.cloud.logging.Logging.TailOption;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNotNull;
 
 import com.google.api.gax.rpc.BidiStream;
 import com.google.cloud.ServiceOptions;
+import com.google.cloud.logging.Logging.TailOption;
 import com.google.cloud.logging.spi.LoggingRpcFactory;
 import com.google.cloud.logging.spi.v2.LoggingRpc;
 import com.google.logging.v2.TailLogEntriesRequest;


### PR DESCRIPTION
This is a speculative PR just to show losalex@, will add issue if it seems like a good idea.

Fixes #TODO

Things our formatter does to this codebase:

1. Add `{ }` consistently after `if` statements. No one-liners-without-curlies allowed.
2. Group overloaded methods together
3. lowerCamelCase variables (`e_name` -> `eName`)
4. UPPER_SNAKE_CASE enums ~`Label.ClusterName` -> `Label.CLUSTER_NAME`). This would be a breaking change if the enum were intended to be public. I think `Label`'s not supposed to be (altho it is `protected` so it *could* be...). **I had to change the clirr allowlist for this!**. `Resource` is definitely private tho. **Update:** reverted the `Label` change because it's potentially breaking, but kept the `Resource` change.
5. Test methods in the form `lowerSnakeCaseOfSystemUnderTest_lowerSnakeCaseOfExpectedBehavior`
6. Don't do static import on classes (`import static com.google.cloud.logging.Logging.TailOption`).
7. Each top-level class gets its own file (`ResourceTypeEnvironmentGetterImpl`)