### PR TITLE
fix: Add flush() calls in samples

### DIFF
--- a/samples/snippets/src/main/java/com/example/logging/QuickstartSample.java
+++ b/samples/snippets/src/main/java/com/example/logging/QuickstartSample.java
@@ -53,6 +53,9 @@ public class QuickstartSample {
 
       // Writes the log entry asynchronously
       logging.write(Collections.singleton(entry));
+
+      // Flush any pending log entries just before Logging is closed
+      logging.flush();
     }
     System.out.printf("Logged: %s%n", textPayload);
   }

--- a/samples/snippets/src/main/java/com/example/logging/QuickstartSample.java
+++ b/samples/snippets/src/main/java/com/example/logging/QuickstartSample.java
@@ -54,7 +54,7 @@ public class QuickstartSample {
       // Writes the log entry asynchronously
       logging.write(Collections.singleton(entry));
 
-      // Flush any pending log entries just before Logging is closed
+      // Optional - flush any pending log entries just before Logging is closed
       logging.flush();
     }
     System.out.printf("Logged: %s%n", textPayload);

--- a/samples/snippets/src/main/java/com/example/logging/WriteLogEntry.java
+++ b/samples/snippets/src/main/java/com/example/logging/WriteLogEntry.java
@@ -48,7 +48,7 @@ public class WriteLogEntry {
       // Writes the log entry asynchronously
       logging.write(Collections.singleton(entry));
       
-      // Flush any pending log entries just before Logging is closed
+      // Optional - flush any pending log entries just before Logging is closed
       logging.flush();      
     }
     System.out.printf("Wrote to %s\n", logName);

--- a/samples/snippets/src/main/java/com/example/logging/WriteLogEntry.java
+++ b/samples/snippets/src/main/java/com/example/logging/WriteLogEntry.java
@@ -45,7 +45,11 @@ public class WriteLogEntry {
               .setResource(MonitoredResource.newBuilder("global").build())
               .build();
 
+      // Writes the log entry asynchronously
       logging.write(Collections.singleton(entry));
+      
+      // Flush any pending log entries just before Logging is closed
+      logging.flush();      
     }
     System.out.printf("Wrote to %s\n", logName);
   }

--- a/samples/snippets/src/main/java/com/example/logging/WriteLogEntry.java
+++ b/samples/snippets/src/main/java/com/example/logging/WriteLogEntry.java
@@ -47,9 +47,9 @@ public class WriteLogEntry {
 
       // Writes the log entry asynchronously
       logging.write(Collections.singleton(entry));
-      
+
       // Optional - flush any pending log entries just before Logging is closed
-      logging.flush();      
+      logging.flush();
     }
     System.out.printf("Wrote to %s\n", logName);
   }


### PR DESCRIPTION
Adding optional `flush()` calls in samples to provide a visibility for this option due to recent questions
