### PR TITLE
fix: Logging SDK not applying quota limits for project set using quotaProjectId

### DIFF
--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/GrpcLoggingRpc.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/GrpcLoggingRpc.java
@@ -122,6 +122,7 @@ public class GrpcLoggingRpc implements LoggingRpc {
                   .setDefaultCallContext(GrpcCallContext.of(managedChannel, CallOptions.DEFAULT))
                   .setBackgroundResources(
                       Collections.<BackgroundResource>singletonList(transportChannel))
+                  .setQuotaProjectId(options.getQuotaProjectId())
                   .build();
         } catch (Exception ex) {
           throw new IOException(ex);
@@ -144,6 +145,7 @@ public class GrpcLoggingRpc implements LoggingRpc {
                 .build();
         HeaderProvider headerProvider = options.getMergedHeaderProvider(internalHeaderProvider);
         settingsBuilder.setInternalHeaderProvider(headerProvider);
+        settingsBuilder.setQuotaProjectId(options.getQuotaProjectId());
 
         clientContext = ClientContext.create(settingsBuilder.build());
       }


### PR DESCRIPTION
Customer uses google-cloud-logging SDK to fetch audit logs from their customers. Since they were facing lot of throttling error's because of the quota limitation's set at the service account, they decided to make use of the quotaProjectId field available while creating the Logging object (LoggingOptions Builder). But even after setting this field they see that quota is counted against the service account (Supplied via credentials) instead of the actual project for which call is being made.
The sample code used:

```
LoggingOptions.newBuilder()
    .setProjectId("project-id")
    .setCredentials()
    .setQuotaProjectId("quota-project-id")
    .build()
    .getService();
```
