### PR TITLE
fix: Add safe directory for environment tests

### DIFF
--- a/.kokoro/environment_tests.sh
+++ b/.kokoro/environment_tests.sh
@@ -27,6 +27,7 @@ fi
 # make sure submodule is up to date
 cd "$PROJECT_ROOT"
 git config --global --add safe.directory '*'
+git config --global --add safe.directory /tmpfs/src/github/java-logging
 git submodule update --init --recursive
 cd "${PROJECT_ROOT}/env-tests-logging"
 


### PR DESCRIPTION
Recently some of PR environment tests started to fail with: `fatal: detected dubious ownership in repository at '/tmpfs/src/github/java-logging'` Adding the safe directory for Java to prevent failures.

