### PR TITLE
feat: Update release-please.yml with correct path

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -11,4 +11,4 @@ branches:
     releaseType: java-backport
     branch: 3.7.x
 extraFiles:
-  - src/main/java/com/google/cloud/logging/Instrumentation.java
+  - blob/main/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java

--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -11,4 +11,4 @@ branches:
     releaseType: java-backport
     branch: 3.7.x
 extraFiles:
-  - blob/main/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
+  - google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java


### PR DESCRIPTION
It seems that blob/main/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java should be used for annotations

