### PR TITLE
fix: Fix failing instrumentation test preventing release

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ implementation 'com.google.cloud:google-cloud-logging'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-logging:3.12.1'
+implementation 'com.google.cloud:google-cloud-logging:3.13.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.12.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.13.0"
 ```
 
 ## Authentication

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
@@ -233,7 +233,13 @@ public final class Instrumentation {
     return libraryVersion;
   }
 
-  private static String truncateValue(String value) {
+  /**
+   * Trancates given string to MAX_DIAGNOSTIC_VALUE_LENGTH and adds "*" of reduced suffix
+   *
+   * @param value {String} Value to be truncated
+   * @return The truncated string
+   */
+  public static String truncateValue(String value) {
     if (Strings.isNullOrEmpty(value) || value.length() < MAX_DIAGNOSTIC_VALUE_LENGTH) {
       return value;
     }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
@@ -37,6 +37,9 @@ public final class Instrumentation {
   public static final String INSTRUMENTATION_NAME_KEY = "name";
   public static final String INSTRUMENTATION_VERSION_KEY = "version";
   public static final String JAVA_LIBRARY_NAME_PREFIX = "java";
+  // Using release-please annotations to update DEFAULT_INSTRUMENTATION_VERSION with latest version.
+  // See
+  // https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files
   // {x-version-update-start:google-cloud-logging:current}
   public static final String DEFAULT_INSTRUMENTATION_VERSION = "3.13.0";
   // {x-version-update-end}

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
@@ -234,7 +234,7 @@ public final class Instrumentation {
   }
 
   /**
-   * Trancates given string to MAX_DIAGNOSTIC_VALUE_LENGTH and adds "*" of reduced suffix
+   * Trancates given string to MAX_DIAGNOSTIC_VALUE_LENGTH and adds "*" instead of reduced suffix
    *
    * @param value {String} Value to be truncated
    * @return The truncated string

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/InstrumentationTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/InstrumentationTest.java
@@ -51,7 +51,10 @@ public class InstrumentationTest {
         1,
         2,
         new HashSet<>(Arrays.asList(Instrumentation.JAVA_LIBRARY_NAME_PREFIX)),
-        new HashSet<>(Arrays.asList(Instrumentation.getLibraryVersion(Instrumentation.class))));
+        new HashSet<>(
+            Arrays.asList(
+                Instrumentation.truncateValue(
+                    Instrumentation.getLibraryVersion(Instrumentation.class)))));
   }
 
   @Test
@@ -78,7 +81,9 @@ public class InstrumentationTest {
         new HashSet<>(Arrays.asList(Instrumentation.JAVA_LIBRARY_NAME_PREFIX, JAVA_OTHER_NAME)),
         new HashSet<>(
             Arrays.asList(
-                Instrumentation.getLibraryVersion(Instrumentation.class), JAVA_OTHER_VERSION)));
+                Instrumentation.truncateValue(
+                    Instrumentation.getLibraryVersion(Instrumentation.class)),
+                JAVA_OTHER_VERSION)));
   }
 
   @Test
@@ -92,7 +97,10 @@ public class InstrumentationTest {
         0,
         1,
         new HashSet<>(Arrays.asList(Instrumentation.JAVA_LIBRARY_NAME_PREFIX)),
-        new HashSet<>(Arrays.asList(Instrumentation.getLibraryVersion(Instrumentation.class))));
+        new HashSet<>(
+            Arrays.asList(
+                Instrumentation.truncateValue(
+                    Instrumentation.getLibraryVersion(Instrumentation.class)))));
   }
 
   public static JsonPayload generateInstrumentationPayload(

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingHandlerTest.java
@@ -171,7 +171,8 @@ public class LoggingHandlerTest {
       LogEntry.newBuilder(
               InstrumentationTest.generateInstrumentationPayload(
                   Instrumentation.JAVA_LIBRARY_NAME_PREFIX,
-                  Instrumentation.getLibraryVersion(Instrumentation.class)))
+                  Instrumentation.truncateValue(
+                      Instrumentation.getLibraryVersion(Instrumentation.class))))
           .setLogName(Instrumentation.INSTRUMENTATION_LOG_NAME)
           .build();
 

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -2333,7 +2333,8 @@ public class LoggingImplTest {
         LogEntry.newBuilder(
                 InstrumentationTest.generateInstrumentationPayload(
                     Instrumentation.JAVA_LIBRARY_NAME_PREFIX,
-                    Instrumentation.getLibraryVersion(Instrumentation.class)))
+                    Instrumentation.truncateValue(
+                        Instrumentation.getLibraryVersion(Instrumentation.class))))
             .setLogName(Instrumentation.INSTRUMENTATION_LOG_NAME)
             .build();
     WriteLogEntriesRequest request =


### PR DESCRIPTION
Fix failing tests which did not included truncation logic for library version.
Fix relate to #[1178](https://github.com/googleapis/java-logging/issues/1178)
