### PR TITLE
fix: Wrong order of libraries info in instrumentation

### DIFF
--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
@@ -163,8 +163,7 @@ public final class Instrumentation {
     }
     Struct libraryInfo = createInfoStruct(libraryName, libraryVersion);
     ListValue.Builder libraryList = ListValue.newBuilder();
-    // Append first the library info for this library
-    libraryList.addValues(Value.newBuilder().setStructValue(libraryInfo).build());
+    // First add instrumentation data of other libraries to a list if any
     if (existingLibraryList != null) {
       for (Value val : existingLibraryList.getValuesList()) {
         if (val.hasStructValue()) {
@@ -190,6 +189,8 @@ public final class Instrumentation {
         }
       }
     }
+    // At last, append this library info to a list
+    libraryList.addValues(Value.newBuilder().setStructValue(libraryInfo).build());
     return libraryList.build();
   }
 


### PR DESCRIPTION
The instrumentation of each library should be appended to the end of list, so the inheriting library should be always first
