### PR TITLE
fix: Test failures due to RESOURCE_EXHAUSTED

### DIFF
--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITSinkTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITSinkTest.java
@@ -31,10 +31,23 @@ import com.google.cloud.logging.LoggingException;
 import com.google.cloud.logging.Sink;
 import com.google.cloud.logging.SinkInfo;
 import com.google.common.collect.Sets;
+import java.util.Iterator;
 import java.util.Set;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ITSinkTest extends BaseSystemTest {
+
+  @BeforeClass
+  public static void setUp() {
+    // Cleanup all stucked sinks if any
+    Logging.ListOption[] options = {Logging.ListOption.pageSize(50)};
+    Page<Sink> sinkPage = logging.listSinks(options);
+    Iterator<Sink> iterator = sinkPage.iterateAll().iterator();
+    while (iterator.hasNext()) {
+      iterator.next().delete();
+    }
+  }
 
   @Test
   public void testCreateGetUpdateAndDeleteSink() {

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITSinkTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/it/ITSinkTest.java
@@ -45,7 +45,12 @@ public class ITSinkTest extends BaseSystemTest {
     Page<Sink> sinkPage = logging.listSinks(options);
     Iterator<Sink> iterator = sinkPage.iterateAll().iterator();
     while (iterator.hasNext()) {
-      iterator.next().delete();
+      Sink sink = iterator.next();
+      try {
+        sink.delete();
+      } catch (Exception ex) {
+        System.err.println("ERROR: Failed to delete a " + sink.getName() + " sink, error: " + ex);
+      }
     }
   }
 


### PR DESCRIPTION
Getting too many test failures related to RESOURCE_EXHAUSTED. The issue seems in many sinks which were not deleted properly - adding a global setup for running through sinks and deleting those.
Fixes #[1194](https://github.com/googleapis/java-logging/issues/1194) and #[1195](https://github.com/googleapis/java-logging/issues/1195)
