### PR TITLE
fix: Add a partner team as approvers for PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*                       @googleapis/api-logging @googleapis/yoshi-java
+*                       @googleapis/api-logging @googleapis/yoshi-java @googleapis/api-logging-partners
 
 # The java-samples-reviewers team is the default owner for samples changes
 samples/**/*.java       @googleapis/java-samples-reviewers @googleapis/api-logging

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -56,3 +56,5 @@ permissionRules:
     permission: admin
   - team: yoshi-java
     permission: push
+  - team: api-logging-partners
+    permission: push


### PR DESCRIPTION
Adding @googleapis/api-logging-partners to contain more people who can approve PRs

