### PR TITLE
feat: setup 3.15.x lts branch

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -17,6 +17,13 @@ branches:
       - >-
         google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
     branch: 3.13.x
+  - bumpMinorPreMajor: true
+    handleGHRelease: true
+    releaseType: java-backport
+    extraFiles:
+      - >-
+        google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
+    branch: 3.15.x
 extraFiles:
   - >-
     google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -66,6 +66,23 @@ branchProtectionRules:
       - OwlBot Post Processor
       - 'Kokoro - Test: Java GraalVM Native Image'
       - 'Kokoro - Test: Java 17 GraalVM Native Image'
+  - pattern: 3.15.x
+    isAdminEnforced: true
+    requiredApprovingReviewCount: 1
+    requiresCodeOwnerReviews: true
+    requiresStrictStatusChecks: false
+    requiredStatusCheckContexts:
+      - dependencies (17)
+      - lint
+      - clirr
+      - units (8)
+      - units (11)
+      - 'Kokoro - Test: Integration'
+      - cla/google
+      - OwlBot Post Processor
+      - 'Kokoro - Test: Java GraalVM Native Image'
+      - 'Kokoro - Test: Java 17 GraalVM Native Image'
+      - javadoc
 permissionRules:
   - team: yoshi-admins
     permission: admin

--- a/README.md
+++ b/README.md
@@ -52,20 +52,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.32.0')
+implementation platform('com.google.cloud:libraries-bom:26.33.0')
 
 implementation 'com.google.cloud:google-cloud-logging'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-logging:3.15.17'
+implementation 'com.google.cloud:google-cloud-logging:3.16.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.15.17"
+libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.16.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -452,7 +452,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-logging/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-logging.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-logging/3.15.17
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-logging/3.16.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles


### PR DESCRIPTION
enable releases

```
release-brancher create-pull-request \
  --branch-name="3.15.x" \
  --target-tag="v3.15.6" \
  --repo="googleapis/java-logging" \
  --pull-request-title="feat: setup 3.15.x lts branch" \
  --release-type=java-backport
```

* LTS branch 3.15.x based on 3.15.6, not 3.15.7 which uses an incompatible shared-dependencies 3.13.1.
* 'feat' commit to trigger minor version bump on next release.