### PR TITLE
ci: javadoc as a required check

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -18,6 +18,7 @@ branchProtectionRules:
       - OwlBot Post Processor
       - 'Kokoro - Test: Java GraalVM Native Image'
       - 'Kokoro - Test: Java 17 GraalVM Native Image'
+      - javadoc
   - pattern: java7
     isAdminEnforced: true
     requiredApprovingReviewCount: 1

--- a/README.md
+++ b/README.md
@@ -52,20 +52,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.21.0')
+implementation platform('com.google.cloud:libraries-bom:26.22.0')
 
 implementation 'com.google.cloud:google-cloud-logging'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-logging:3.15.7'
+implementation 'com.google.cloud:google-cloud-logging:3.15.8'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.15.7"
+libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.15.8"
 ```
 <!-- {x-version-update-end} -->
 
@@ -452,7 +452,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-logging/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-logging.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-logging/3.15.7
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-logging/3.15.8
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles


### PR DESCRIPTION
Manual configuration of the required check at Settings tab has been reverted. Adding that back via sync-repo-settings.yaml.
