### PR TITLE
Add a null check

### DIFF
--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
@@ -766,7 +766,9 @@ public class LogEntry implements Serializable {
     builder.setSeverity(Severity.fromPb(entryPb.getSeverity()));
     if (!entryPb.getLogName().isEmpty()) {
       LogName name = LogName.parse(entryPb.getLogName());
-      builder.setLogName(name.getLog());
+      if (name != null) {
+        builder.setLogName(name.getLog());
+      }  
       LogDestinationName resource = LogDestinationName.fromLogName(name);
       if (resource != null) {
         builder.setDestination(resource);


### PR DESCRIPTION
In file: LogEntry.java, class: `LogEntry`, there is a method `fromPb` in which there is a potential Null pointer dereference. This may throw an unexpected null pointer exception which, if unhandled, may crash the program. 

In line 768, the variable `name` is assigned by a method call `LogName.parse`. This method may return a null value. Then in 769, there is the potential null dereference case. This is where the fix is suggested. An argument may be that the method call `LogName.parse` is designed to not return null at all. However, in line 770, we pass `name` to a method where the method may return null if `name` is null. Right after this, in line 771 we do a null check on the return value. This suggests that we may have catered for `name` being null inside the method `fromLogName` in 770; we should similarly do null check in line 769 too. 
Note that there may be a case that the `LogName.parse` is guaranteed to return null. That is something I am leaving for the developer to decide.


I introduced a null check to protect from an exception. A developer should verify this. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.