### PR TITLE
build: do not declare javadoc plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,20 +52,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.23.0')
+implementation platform('com.google.cloud:libraries-bom:26.24.0')
 
 implementation 'com.google.cloud:google-cloud-logging'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-logging:3.15.9'
+implementation 'com.google.cloud:google-cloud-logging:3.15.10'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.15.9"
+libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.15.10"
 ```
 <!-- {x-version-update-end} -->
 
@@ -452,7 +452,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-logging/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-logging.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-logging/3.15.9
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-logging/3.15.10
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.0</version>
         <reportSets>
           <reportSet>
             <id>html</id>


### PR DESCRIPTION
The maven-javadoc-plugin version is defined in the shared config pom.xml.
https://github.com/googleapis/java-shared-config/blob/778a547a09de71dbf9e5a42b155f12d15c319864/pom.xml#L472

The removal of the 4 lines corresponds to the lines touched by the recent RenovateBot:
https://github.com/googleapis/java-logging/pull/1432

Parent issue: https://github.com/googleapis/java-shared-config/issues/673