### PR TITLE
ci: unmanaged dependency check

### DIFF
--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -1,0 +1,22 @@
+on:
+  pull_request:
+name: Unmanaged dependency check
+jobs:
+  unmanaged_dependency_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+      - name: Install modules
+        shell: bash
+        run: |
+          # No argument to build.sh installs the modules in local Maven
+          # repository
+          .kokoro/build.sh
+      - name: Unmanaged dependency check
+        uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@unmanaged-dependencies-check-latest
+        with:
+          bom-path: google-cloud-logging-bom/pom.xml

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ implementation 'com.google.cloud:google-cloud-logging'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-logging:3.15.15'
+implementation 'com.google.cloud:google-cloud-logging:3.15.16'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.15.15"
+libraryDependencies += "com.google.cloud" % "google-cloud-logging" % "3.15.16"
 ```
 <!-- {x-version-update-end} -->
 
@@ -452,7 +452,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-logging/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-logging.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-logging/3.15.15
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-logging/3.15.16
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles


### PR DESCRIPTION
Cindy has reviewed go/cloud-sdk-java-dependency-governance-design. This new check would fail if someone adds an unknown new dependency to pom.xml files. All new dependencies should be added in https://github.com/googleapis/sdk-platform-java/blob/main/java-shared-dependencies/third-party-dependencies/pom.xml first.
