### PR TITLE
chore: include recommended_package in repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -13,5 +13,6 @@
   "transport": "grpc",
   "library_type": "GAPIC_COMBO",
   "api_description": "allows you to store, search, analyze, monitor, and alert on log data and events from Google Cloud and Amazon Web Services. Using the BindPlane service, you can also collect this data from over 150 common application components, on-premises systems, and hybrid cloud systems. BindPlane is included with your Google Cloud project at no additional cost.",
-  "codeowner_team": "@googleapis/api-logging @googleapis/yoshi-java @googleapis/api-logging-partners"
+  "codeowner_team": "@googleapis/api-logging @googleapis/yoshi-java @googleapis/api-logging-partners",
+  "recommended_package": "com.google.cloud.logging"
 }

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.34.0')
+implementation platform('com.google.cloud:libraries-bom:26.37.0')
 
 implementation 'com.google.cloud:google-cloud-logging'
 ```


### PR DESCRIPTION
Adds a field for recommended_package as part of the revamped Library Overviews.
See go/cloud-rad-overviews-handwritten-repos for more details