### PR TITLE
chore: make the owlbot postprocessor check non-required

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -15,7 +15,6 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - OwlBot Post Processor
       - 'Kokoro - Test: Java GraalVM Native Image'
       - 'Kokoro - Test: Java 17 GraalVM Native Image'
       - javadoc
@@ -33,7 +32,6 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - OwlBot Post Processor
   - pattern: 3.7.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -48,7 +46,6 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - OwlBot Post Processor
   - pattern: 3.13.x
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
@@ -63,7 +60,6 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - OwlBot Post Processor
       - 'Kokoro - Test: Java GraalVM Native Image'
       - 'Kokoro - Test: Java 17 GraalVM Native Image'
 permissionRules:


### PR DESCRIPTION
We will soon disable the Owlbot postprocessor. This is part of the effort to enable hermetic generation in this repo ([context](https://docs.google.com/document/d/1wrpyBtphdenM3BNelcnpBKGADYrGJUo686HXvSA0h-0/edit?pli=1&tab=t.0#bookmark=kix.914gcjvdwt3u))