### PR TITLE
feat: introduce `java.time` methods

### DIFF
--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/HttpRequest.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/HttpRequest.java
@@ -16,14 +16,18 @@
 
 package com.google.cloud.logging;
 
+import static com.google.api.gax.util.TimeConversionUtils.toJavaTimeDuration;
+import static com.google.api.gax.util.TimeConversionUtils.toThreetenDuration;
+
 import com.google.api.core.ApiFunction;
+import com.google.api.core.ObsoleteApi;
 import com.google.cloud.StringEnumType;
 import com.google.cloud.StringEnumValue;
 import com.google.common.base.MoreObjects;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.Objects;
-import org.threeten.bp.Duration;
 
 /**
  * Objects of this class represent information about the (optional) HTTP request associated with a
@@ -51,7 +55,7 @@ public final class HttpRequest implements Serializable {
   private final boolean cacheHit;
   private final boolean cacheValidatedWithOriginServer;
   private final Long cacheFillBytes;
-  private final Duration latency;
+  private final java.time.Duration latency;
 
   /** The HTTP request method. */
   public static final class RequestMethod extends StringEnumValue {
@@ -112,7 +116,7 @@ public final class HttpRequest implements Serializable {
     private boolean cacheHit;
     private boolean cacheValidatedWithOriginServer;
     private Long cacheFillBytes;
-    private Duration latency;
+    private java.time.Duration latency;
 
     Builder() {}
 
@@ -258,12 +262,18 @@ public final class HttpRequest implements Serializable {
       return this;
     }
 
+    /** This method is obsolete. Use {@link #setLatencyDuration(java.time.Duration)} instead. */
+    @ObsoleteApi("Use setLatencyDuration(java.time.Duration) instead")
+    public Builder setLatency(org.threeten.bp.Duration latency) {
+      return setLatencyDuration(toJavaTimeDuration(latency));
+    }
+
     /**
      * Sets the latency on the server, from the time the request was received until the response was
      * sent.
      */
     @CanIgnoreReturnValue
-    public Builder setLatency(Duration latency) {
+    public Builder setLatencyDuration(java.time.Duration latency) {
       this.latency = latency;
       return this;
     }
@@ -393,13 +403,19 @@ public final class HttpRequest implements Serializable {
     return cacheFillBytes;
   }
 
+  /** This method is obsolete. Use {@link #getLatencyDuration()} instead. */
+  @ObsoleteApi("Use getLatencyDuration() instead")
+  public org.threeten.bp.Duration getLatency() {
+    return toThreetenDuration(getLatencyDuration());
+  }
+
   /**
    * Returns the processing latency on the server, from the time the request was received until the
    * response was sent.
    *
    * @return the latency, for null if not populated.
    */
-  public Duration getLatency() {
+  public Duration getLatencyDuration() {
     return latency;
   }
 
@@ -561,7 +577,7 @@ public final class HttpRequest implements Serializable {
     }
     if (requestPb.hasLatency()) {
       // NOTE(pongad): Don't convert to nano; large durations overflow longs!
-      builder.setLatency(
+      builder.setLatencyDuration(
           Duration.ofSeconds(
               requestPb.getLatency().getSeconds(), requestPb.getLatency().getNanos()));
     }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/HttpRequest.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/HttpRequest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.logging;
 
+import static com.google.api.gax.util.TimeConversionUtils.toJavaTimeDuration;
+
 import com.google.api.core.ApiFunction;
 import com.google.cloud.StringEnumType;
 import com.google.cloud.StringEnumValue;
@@ -23,7 +25,6 @@ import com.google.common.base.MoreObjects;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.Serializable;
 import java.util.Objects;
-import org.threeten.bp.Duration;
 
 /**
  * Objects of this class represent information about the (optional) HTTP request associated with a
@@ -51,7 +52,7 @@ public final class HttpRequest implements Serializable {
   private final boolean cacheHit;
   private final boolean cacheValidatedWithOriginServer;
   private final Long cacheFillBytes;
-  private final Duration latency;
+  private final java.time.Duration latency;
 
   /** The HTTP request method. */
   public static final class RequestMethod extends StringEnumValue {
@@ -112,7 +113,7 @@ public final class HttpRequest implements Serializable {
     private boolean cacheHit;
     private boolean cacheValidatedWithOriginServer;
     private Long cacheFillBytes;
-    private Duration latency;
+    private java.time.Duration latency;
 
     Builder() {}
 
@@ -259,11 +260,18 @@ public final class HttpRequest implements Serializable {
     }
 
     /**
+     * This method
+     */
+    public Builder setLatency(org.threeten.bp.Duration latency) {
+      return setLatencyDuration(toJavaTimeDuration(latency));
+    }
+
+    /**
      * Sets the latency on the server, from the time the request was received until the response was
      * sent.
      */
     @CanIgnoreReturnValue
-    public Builder setLatency(Duration latency) {
+    public Builder setLatencyDuration(java.time.Duration latency) {
       this.latency = latency;
       return this;
     }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
@@ -34,6 +34,7 @@ import com.google.logging.v2.LogEntryOperation;
 import com.google.logging.v2.LogEntrySourceLocation;
 import com.google.logging.v2.LogName;
 import java.io.Serializable;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -612,6 +613,14 @@ public class LogEntry implements Serializable {
     }
   }
 
+  static final class DurationSerializer implements JsonSerializer<Duration> {
+    @Override
+    public JsonElement serialize(
+        Duration src, java.lang.reflect.Type typeOfSrc, JsonSerializationContext context) {
+      return new JsonPrimitive(src.toString());
+    }
+  }
+
   static final class SourceLocationSerializer implements JsonSerializer<SourceLocation> {
     @Override
     public JsonElement serialize(
@@ -649,6 +658,7 @@ public class LogEntry implements Serializable {
       checkNotNull(builder);
       this.gson =
           new GsonBuilder()
+              .registerTypeAdapter(Duration.class, new DurationSerializer())
               .registerTypeAdapter(Instant.class, new InstantSerializer())
               .registerTypeAdapter(SourceLocation.class, new SourceLocationSerializer())
               .registerTypeAdapter(HttpRequest.RequestMethod.class, new RequestMethodSerializer())

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LogEntry.java
@@ -34,7 +34,6 @@ import com.google.logging.v2.LogEntryOperation;
 import com.google.logging.v2.LogEntrySourceLocation;
 import com.google.logging.v2.LogName;
 import java.io.Serializable;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -613,14 +612,6 @@ public class LogEntry implements Serializable {
     }
   }
 
-  static final class DurationSerializer implements JsonSerializer<Duration> {
-    @Override
-    public JsonElement serialize(
-        Duration src, java.lang.reflect.Type typeOfSrc, JsonSerializationContext context) {
-      return new JsonPrimitive(src.toString());
-    }
-  }
-
   static final class SourceLocationSerializer implements JsonSerializer<SourceLocation> {
     @Override
     public JsonElement serialize(
@@ -658,7 +649,6 @@ public class LogEntry implements Serializable {
       checkNotNull(builder);
       this.gson =
           new GsonBuilder()
-              .registerTypeAdapter(Duration.class, new DurationSerializer())
               .registerTypeAdapter(Instant.class, new InstantSerializer())
               .registerTypeAdapter(SourceLocation.class, new SourceLocationSerializer())
               .registerTypeAdapter(HttpRequest.RequestMethod.class, new RequestMethodSerializer())

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/testing/RemoteLoggingHelper.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/testing/RemoteLoggingHelper.java
@@ -22,10 +22,10 @@ import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.logging.LoggingOptions;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.threeten.bp.Duration;
 
 /**
  * Utility to create a remote logging configuration for testing. Logging options can be obtained via
@@ -101,13 +101,13 @@ public class RemoteLoggingHelper {
 
   private static RetrySettings retrySettings() {
     return RetrySettings.newBuilder()
-        .setMaxRetryDelay(Duration.ofMillis(30000L))
-        .setTotalTimeout(Duration.ofMillis(120000L))
-        .setInitialRetryDelay(Duration.ofMillis(250L))
+        .setMaxRetryDelayDuration(Duration.ofMillis(30000L))
+        .setTotalTimeoutDuration(Duration.ofMillis(120000L))
+        .setInitialRetryDelayDuration(Duration.ofMillis(250L))
         .setRetryDelayMultiplier(1.0)
-        .setInitialRpcTimeout(Duration.ofMillis(120000L))
+        .setInitialRpcTimeoutDuration(Duration.ofMillis(120000L))
         .setRpcTimeoutMultiplier(1.0)
-        .setMaxRpcTimeout(Duration.ofMillis(120000L))
+        .setMaxRpcTimeoutDuration(Duration.ofMillis(120000L))
         .build();
   }
 

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/ContextTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/ContextTest.java
@@ -29,10 +29,10 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.time.Duration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class ContextTest {
@@ -62,7 +62,7 @@ public class ContextTest {
           .setCacheHit(false)
           .setCacheValidatedWithOriginServer(true)
           .setCacheFillBytes(303L)
-          .setLatency(Duration.ofSeconds(123, 456))
+          .setLatencyDuration(Duration.ofSeconds(123, 456))
           .build();
   private static final HttpRequest PARTIAL_REQUEST =
       HttpRequest.newBuilder()

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/HttpRequestTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/HttpRequestTest.java
@@ -22,10 +22,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.logging.HttpRequest.RequestMethod;
+import java.time.Duration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class HttpRequestTest {
@@ -59,7 +59,7 @@ public class HttpRequestTest {
           .setCacheHit(CACHE_HIT)
           .setCacheValidatedWithOriginServer(CACHE_VALIDATED_WITH_ORIGIN_SERVER)
           .setCacheFillBytes(CACHE_FILL_BYTES)
-          .setLatency(Duration.ofSeconds(123, 456))
+          .setLatencyDuration(Duration.ofSeconds(123, 456))
           .build();
 
   @Test

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingOptionsTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingOptionsTest.java
@@ -27,10 +27,10 @@ import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.TransportOptions;
+import java.time.Duration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class LoggingOptionsTest {
@@ -90,7 +90,7 @@ public class LoggingOptionsTest {
                 .setIsEnabled(true)
                 .setElementCountThreshold(ELEMENTS_TRESHOLD_COUNT)
                 .setRequestByteThreshold(REQUEST_BYTE_TRESHOLD_COUNT)
-                .setDelayThreshold(Duration.ofMillis(DURATION))
+                .setDelayThresholdDuration(Duration.ofMillis(DURATION))
                 .setFlowControlSettings(
                     FlowControlSettings.newBuilder()
                         .setMaxOutstandingElementCount(MAX_OUTSTANDING_ELEMENTS_COUNT)

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,38 @@
             <ignoredUnusedDeclaredDependencies>org.objenesis:objenesis</ignoredUnusedDeclaredDependencies>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>default-jar</id>
+              <phase>package</phase>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+              <configuration>
+                <archive>
+                  <manifestEntries>
+                    <!-- This manifest entry is ignored by java 8.
+                    It allows inter-module access when Gson serializes
+                    the private variables of java.time.Duration -->
+                    <Add-Opens>java.base/java.time=ALL-UNNAMED</Add-Opens>
+                  </manifestEntries>
+                </archive>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <!-- This arg line allows inter-module access when Gson serializes
+            the private variables of java.time.Duration -->
+            <argLine>--add-opens java.base/java.time=ALL-UNNAMED</argLine>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,15 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <!-- This arg line allows inter-module access when Gson serializes
+            the private variables of java.time.Duration -->
+            <argLine>--add-opens java.base/java.time=ALL-UNNAMED</argLine>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>
@@ -299,25 +308,4 @@
       </plugin>
     </plugins>
   </reporting>
-  <profiles>
-    <profile>
-      <id>java9</id>
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <!-- This arg line allows inter-module access when Gson serializes
-              the private variables of java.time.Duration -->
-              <argLine>--add-opens java.base/java.time=ALL-UNNAMED</argLine>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -197,38 +197,6 @@
             <ignoredUnusedDeclaredDependencies>org.objenesis:objenesis</ignoredUnusedDeclaredDependencies>
           </configuration>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>default-jar</id>
-              <phase>package</phase>
-              <goals>
-                <goal>jar</goal>
-              </goals>
-              <configuration>
-                <archive>
-                  <manifestEntries>
-                    <!-- This manifest entry is ignored by java 8.
-                    It allows inter-module access when Gson serializes
-                    the private variables of java.time.Duration -->
-                    <Add-Opens>java.base/java.time=ALL-UNNAMED</Add-Opens>
-                  </manifestEntries>
-                </archive>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <!-- This arg line allows inter-module access when Gson serializes
-            the private variables of java.time.Duration -->
-            <argLine>--add-opens java.base/java.time=ALL-UNNAMED</argLine>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -220,15 +220,6 @@
             </execution>
           </executions>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <!-- This arg line allows inter-module access when Gson serializes
-            the private variables of java.time.Duration -->
-            <argLine>--add-opens java.base/java.time=ALL-UNNAMED</argLine>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
   </build>
@@ -308,4 +299,25 @@
       </plugin>
     </plugins>
   </reporting>
+  <profiles>
+    <profile>
+      <id>java9</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <!-- This arg line allows inter-module access when Gson serializes
+              the private variables of java.time.Duration -->
+              <argLine>--add-opens java.base/java.time=ALL-UNNAMED</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
This PR introduces `java.time` alternatives to existing `org.threeten.bp.*` methods, as well as switching internal variables (if any) to `java.time`

The main constraint is to keep the changes backwards compatible, so for each existing threeten method "`method1(org.threeten.bp.Duration)`" we will add an alternative with a _Duration_ (or _Timestamp_ when applicable) suffix: "`method1Duration(java.time.Duration)`".

For most cases, the implementation will be held in the `java.time` method and the old threeten method will just delegate the call to it. However, for the case of abstract classes, the implementation will be kept in the threeten method to avoid breaking changes (i.e. users that already overloaded the method in their user code).