### PR TITLE
chore: manual update of update_generation_config.sh

### DIFF
--- a/.github/scripts/update_generation_config.sh
+++ b/.github/scripts/update_generation_config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 # This script should be run at the root of the repository.
 # This script is used to update googleapis_commitish, gapic_generator_version,
 # and libraries_bom_version in generation configuration at the time of running
@@ -15,10 +15,8 @@ set -ex
 function get_latest_released_version() {
     local group_id=$1
     local artifact_id=$2
-    group_id_url_path="$(sed 's|\.|/|g' <<< "${group_id}")"
-    url="https://repo1.maven.org/maven2/${group_id_url_path}/${artifact_id}/maven-metadata.xml"
-    xml_content=$(curl -s --fail "${url}")
-    latest=$(xmllint --xpath 'metadata/versioning/latest/text()' - <<< "${xml_content}")
+    json_content=$(curl -s "https://search.maven.org/solrsearch/select?q=g:${group_id}+AND+a:${artifact_id}&core=gav&rows=500&wt=json")
+    latest=$(jq -r '.response.docs[] | select(.v | test("^[0-9]+(\\.[0-9]+)*$")) | .v' <<< "${json_content}" | sort -V | tail -n 1)
     if [[ -z "${latest}" ]]; then
         echo "The latest version of ${group_id}:${artifact_id} is empty."
         echo "The returned json from maven.org is invalid: ${json_content}"

--- a/.github/workflows/update_generation_config.yaml
+++ b/.github/workflows/update_generation_config.yaml
@@ -18,7 +18,6 @@ on:
   schedule:
   - cron: '0 2 * * *'
   workflow_dispatch:
-
 jobs:
   update-generation-config:
     runs-on: ubuntu-24.04
@@ -30,6 +29,9 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
+    - name: Install Dependencies
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y libxml2-utils
     - name: Update params in generation config to latest
       shell: bash
       run: |
@@ -41,4 +43,3 @@ jobs:
           --repo ${{ github.repository }}
       env:
         GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
-

--- a/.github/workflows/update_generation_config.yaml
+++ b/.github/workflows/update_generation_config.yaml
@@ -18,6 +18,7 @@ on:
   schedule:
   - cron: '0 2 * * *'
   workflow_dispatch:
+
 jobs:
   update-generation-config:
     runs-on: ubuntu-24.04
@@ -29,9 +30,6 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
-    - name: Install Dependencies
-      shell: bash
-      run: sudo apt-get update && sudo apt-get install -y libxml2-utils
     - name: Update params in generation config to latest
       shell: bash
       run: |
@@ -43,3 +41,4 @@ jobs:
           --repo ${{ github.repository }}
       env:
         GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
+


### PR DESCRIPTION
Unfortunately, https://github.com/googleapis/sdk-platform-java/pull/3853 cannot be automatically propagated. 

This PR manually updates this script with the latest.

Confirmation in https://github.com/googleapis/java-logging/actions/runs/16504685245

