### PR TITLE
chore: cleanup release-please config

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -3,16 +3,16 @@ handleGHRelease: true
 releaseType: java-yoshi
 branches:
     - branch: java7
-    - releaseType: java-backport
-      branch: 3.7.x
-    - releaseType: java-backport
-      branch: 3.13.x
-    - releaseType: java-backport
-      branch: 3.17.x
-    - releaseType: java-backport
-      branch: 3.21.x
-    - releaseType: java-backport
-      branch: 3.22.x
+    - branch: 3.7.x
+      releaseType: java-backport
+    - branch: 3.13.x
+      releaseType: java-backport
+    - branch: 3.17.x
+      releaseType: java-backport
+    - branch: 3.21.x
+      releaseType: java-backport
+    - branch: 3.22.x
+      releaseType: java-backport
     - branch: protobuf-4.x-rc
       manifest: true
 extraFiles:

--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -2,50 +2,19 @@ bumpMinorPreMajor: true
 handleGHRelease: true
 releaseType: java-yoshi
 branches:
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-yoshi
-    branch: java7
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-backport
-    branch: 3.7.x
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-backport
-    extraFiles:
-      - >-
-        google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
-    branch: 3.13.x
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-backport
-    extraFiles:
-      - >-
-        google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
-    branch: 3.17.x
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-backport
-    extraFiles:
-      - >-
-        google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
-    branch: 3.21.x
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-backport
-    extraFiles:
-      - >-
-        google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
-    branch: 3.22.x
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-yoshi
-    extraFiles:
-      - >-
-        google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
-    branch: protobuf-4.x-rc
-    manifest: true
+    - branch: java7
+    - releaseType: java-backport
+      branch: 3.7.x
+    - releaseType: java-backport
+      branch: 3.13.x
+    - releaseType: java-backport
+      branch: 3.17.x
+    - releaseType: java-backport
+      branch: 3.21.x
+    - releaseType: java-backport
+      branch: 3.22.x
+    - branch: protobuf-4.x-rc
+      manifest: true
 extraFiles:
-  - >-
-    google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java
+    - >-
+      google-cloud-logging/src/main/java/com/google/cloud/logging/Instrumentation.java


### PR DESCRIPTION
This PR cleans up the .github/release-please.yml file by removing redundant options and the bump-minor-pre-major setting for major releases.