### PR TITLE
chore: remove api-logging teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,4 @@
 # @googleapis/cloud-java-team-teamsync are the default owners for changes in this repo
 *                       @googleapis/cloud-java-team-teamsync
 
-# @googleapis/cloud-java-team-teamsync are the default owners for samples changes
 samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,8 @@
 
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
-# @googleapis/yoshi-java are the default owners for changes in this repo
-*                       @googleapis/yoshi-java
+# @googleapis/cloud-java-team-teamsync are the default owners for changes in this repo
+*                       @googleapis/cloud-java-team-teamsync
 
-# @googleapis/yoshi-java are the default owners for samples changes
+# @googleapis/cloud-java-team-teamsync are the default owners for samples changes
 samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,8 @@
 
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
-# @googleapis/api-logging @googleapis/yoshi-java @googleapis/api-logging-partners are the default owners for changes in this repo
-*                       @googleapis/api-logging @googleapis/yoshi-java @googleapis/api-logging-partners
+# @googleapis/yoshi-java are the default owners for changes in this repo
+*                       @googleapis/yoshi-java
 
-# @googleapis/api-logging @googleapis/yoshi-java @googleapis/api-logging-partners are the default owners for samples changes
-samples/**/*.java       @googleapis/java-samples-reviewers @googleapis/api-logging @googleapis/api-logging-partners
+# @googleapis/yoshi-java are the default owners for samples changes
+samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,9 +1,9 @@
 # Configuration for the Blunderbuss GitHub app. For more info see
 # https://github.com/googleapis/repo-automation-bots/tree/main/packages/blunderbuss
 assign_issues:
-  - googleapis/yoshi-java
+  - googleapis/cloud-java-team-teamsync
 assign_prs:
-  - googleapis/yoshi-java
+  - googleapis/cloud-java-team-teamsync
 assign_prs_by:
   - labels:
     - samples

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,9 +1,9 @@
 # Configuration for the Blunderbuss GitHub app. For more info see
 # https://github.com/googleapis/repo-automation-bots/tree/main/packages/blunderbuss
 assign_issues:
-  - googleapis/api-logging-java-reviewers
+  - googleapis/yoshi-java
 assign_prs:
-  - googleapis/api-logging-java-reviewers
+  - googleapis/yoshi-java
 assign_prs_by:
   - labels:
     - samples

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -125,5 +125,3 @@ permissionRules:
     permission: admin
   - team: yoshi-java
     permission: push
-  - team: api-logging-partners
-    permission: push

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -123,5 +123,5 @@ permissionRules:
     permission: admin
   - team: yoshi-java-admins
     permission: admin
-  - team: yoshi-java
+  - team: cloud-java-team-teamsync
     permission: push

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -13,7 +13,7 @@
   "api_id": "logging.googleapis.com",
   "library_type": "GAPIC_COMBO",
   "requires_billing": true,
-  "codeowner_team": "@googleapis/api-logging @googleapis/yoshi-java @googleapis/api-logging-partners",
+  "codeowner_team": "@googleapis/yoshi-java",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559764",
   "recommended_package": "com.google.cloud.logging"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -13,7 +13,7 @@
   "api_id": "logging.googleapis.com",
   "library_type": "GAPIC_COMBO",
   "requires_billing": true,
-  "codeowner_team": "@googleapis/yoshi-java",
+  "codeowner_team": "@googleapis/cloud-java-team-teamsync",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559764",
   "recommended_package": "com.google.cloud.logging"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -13,7 +13,7 @@
   "api_id": "logging.googleapis.com",
   "library_type": "GAPIC_COMBO",
   "requires_billing": true,
-  "codeowner_team": "@googleapis/yoshi-java",
+  "codeowner_team": "@googleapis/api-logging @googleapis/yoshi-java @googleapis/api-logging-partners",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559764",
   "recommended_package": "com.google.cloud.logging"
 }

--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -16,7 +16,7 @@ libraries:
     transport: grpc
     library_type: GAPIC_COMBO
     api_description: allows you to store, search, analyze, monitor, and alert on log data and events from Google Cloud and Amazon Web Services. Using the BindPlane service, you can also collect this data from over 150 common application components, on-premises systems, and hybrid cloud systems. BindPlane is included with your Google Cloud project at no additional cost.
-    codeowner_team: '@googleapis/yoshi-java'
+    codeowner_team: '@googleapis/cloud-java-team-teamsync'
     recommended_package: com.google.cloud.logging
     GAPICs:
       - proto_path: google/logging/v2

--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -16,7 +16,7 @@ libraries:
     transport: grpc
     library_type: GAPIC_COMBO
     api_description: allows you to store, search, analyze, monitor, and alert on log data and events from Google Cloud and Amazon Web Services. Using the BindPlane service, you can also collect this data from over 150 common application components, on-premises systems, and hybrid cloud systems. BindPlane is included with your Google Cloud project at no additional cost.
-    codeowner_team: '@googleapis/api-logging @googleapis/yoshi-java @googleapis/api-logging-partners'
+    codeowner_team: '@googleapis/yoshi-java'
     recommended_package: com.google.cloud.logging
     GAPICs:
       - proto_path: google/logging/v2


### PR DESCRIPTION
Removing @googleapis/api-logging, @googleapis/api-logging-partners, and @googleapis/api-logging-reviewers. Replaced with @googleapis/yoshi-java.

b/476446922