### PR TITLE
chore: replace old java team with cloud-sdk-java-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
-# @googleapis/cloud-java-team-teamsync are the default owners for changes in this repo
-*                       @googleapis/cloud-java-team-teamsync
+# @googleapis/cloud-sdk-java-team are the default owners for changes in this repo
+*                       @googleapis/cloud-sdk-java-team
 
 samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,9 +1,9 @@
 # Configuration for the Blunderbuss GitHub app. For more info see
 # https://github.com/googleapis/repo-automation-bots/tree/main/packages/blunderbuss
 assign_issues:
-  - googleapis/cloud-java-team-teamsync
+  - googleapis/cloud-sdk-java-team
 assign_prs:
-  - googleapis/cloud-java-team-teamsync
+  - googleapis/cloud-sdk-java-team
 assign_prs_by:
   - labels:
     - samples

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -13,7 +13,7 @@
   "api_id": "logging.googleapis.com",
   "library_type": "GAPIC_COMBO",
   "requires_billing": true,
-  "codeowner_team": "@googleapis/cloud-java-team-teamsync",
+  "codeowner_team": "@googleapis/cloud-sdk-java-team",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559764",
   "recommended_package": "com.google.cloud.logging"
 }

--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -16,7 +16,7 @@ libraries:
     transport: grpc
     library_type: GAPIC_COMBO
     api_description: allows you to store, search, analyze, monitor, and alert on log data and events from Google Cloud and Amazon Web Services. Using the BindPlane service, you can also collect this data from over 150 common application components, on-premises systems, and hybrid cloud systems. BindPlane is included with your Google Cloud project at no additional cost.
-    codeowner_team: '@googleapis/cloud-java-team-teamsync'
+    codeowner_team: '@googleapis/cloud-sdk-java-team'
     recommended_package: com.google.cloud.logging
     GAPICs:
       - proto_path: google/logging/v2


### PR DESCRIPTION
Replace old teams with new ones.
b/479542582